### PR TITLE
fix: import all parameters in all integration resources

### DIFF
--- a/lacework/resource_lacework_integration_aws_cfg.go
+++ b/lacework/resource_lacework_integration_aws_cfg.go
@@ -126,23 +126,27 @@ func resourceLaceworkIntegrationAwsCfgRead(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	log.Println("[INFO] Verifying server response data")
-	err = validateAwsIntegrationResponse(&response)
-	if err != nil {
-		return err
+	for _, integration := range response.Data {
+		if integration.IntgGuid == d.Id() {
+			d.Set("name", integration.Name)
+			d.Set("intg_guid", integration.IntgGuid)
+			d.Set("enabled", integration.Enabled == 1)
+			d.Set("created_or_updated_time", integration.CreatedOrUpdatedTime)
+			d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
+			d.Set("type_name", integration.TypeName)
+			d.Set("org_level", integration.IsOrg == 1)
+
+			creds := make(map[string]string)
+			creds["role_arn"] = integration.Data.Credentials.RoleArn
+			creds["external_id"] = integration.Data.Credentials.ExternalId
+			d.Set("credentials", []map[string]string{creds})
+
+			log.Printf("[INFO] Read AWS_CFG integration with guid: %v\n", integration.IntgGuid)
+			return nil
+		}
 	}
 
-	// @afiune at this point of time, we know the data field has a single value
-	integration := response.Data[0]
-	d.Set("name", integration.Name)
-	d.Set("intg_guid", integration.IntgGuid)
-	d.Set("enabled", integration.Enabled == 1)
-	d.Set("created_or_updated_time", integration.CreatedOrUpdatedTime)
-	d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
-	d.Set("type_name", integration.TypeName)
-	d.Set("org_level", integration.IsOrg == 1)
-
-	log.Printf("[INFO] Read AWS_CFG integration with guid: %v\n", integration.IntgGuid)
+	d.SetId("")
 	return nil
 }
 

--- a/lacework/resource_lacework_integration_azure_al.go
+++ b/lacework/resource_lacework_integration_azure_al.go
@@ -134,23 +134,28 @@ func resourceLaceworkIntegrationAzureActivityLogRead(d *schema.ResourceData, met
 		return err
 	}
 
-	log.Println("[INFO] Verifying server response data")
-	err = validateAzureIntegrationResponse(&response)
-	if err != nil {
-		return err
+	for _, integration := range response.Data {
+		if integration.IntgGuid == d.Id() {
+			d.Set("name", integration.Name)
+			d.Set("intg_guid", integration.IntgGuid)
+			d.Set("enabled", integration.Enabled == 1)
+			d.Set("created_or_updated_time", integration.CreatedOrUpdatedTime)
+			d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
+			d.Set("type_name", integration.TypeName)
+			d.Set("org_level", integration.IsOrg == 1)
+
+			creds := make(map[string]string)
+			creds["client_id"] = integration.Data.Credentials.ClientID
+			d.Set("credentials", []map[string]string{creds})
+			d.Set("queue_url", integration.Data.QueueUrl)
+			d.Set("tenant_id", integration.Data.TenantID)
+
+			log.Printf("[INFO] Read AZURE_AL_SEQ integration with guid: %v\n", integration.IntgGuid)
+			return nil
+		}
 	}
 
-	// @afiune at this point of time, we know the data field has a single value
-	integration := response.Data[0]
-	d.Set("name", integration.Name)
-	d.Set("intg_guid", integration.IntgGuid)
-	d.Set("enabled", integration.Enabled == 1)
-	d.Set("created_or_updated_time", integration.CreatedOrUpdatedTime)
-	d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
-	d.Set("type_name", integration.TypeName)
-	d.Set("org_level", integration.IsOrg == 1)
-
-	log.Printf("[INFO] Read AZURE_AL_SEQ integration with guid: %v\n", integration.IntgGuid)
+	d.SetId("")
 	return nil
 }
 

--- a/lacework/resource_lacework_integration_gcp_at.go
+++ b/lacework/resource_lacework_integration_gcp_at.go
@@ -178,14 +178,19 @@ func resourceLaceworkIntegrationGcpAtRead(d *schema.ResourceData, meta interface
 			d.Set("name", integration.Name)
 			d.Set("intg_guid", integration.IntgGuid)
 			d.Set("enabled", integration.Enabled == 1)
-			d.Set("resource_level", integration.Data.IdType)
-			d.Set("resource_id", integration.Data.ID)
-			d.Set("subscription", integration.Data.SubscriptionName)
-
 			d.Set("created_or_updated_time", integration.CreatedOrUpdatedTime)
 			d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
 			d.Set("type_name", integration.TypeName)
 			d.Set("org_level", integration.IsOrg == 1)
+
+			creds := make(map[string]string)
+			creds["client_id"] = integration.Data.Credentials.ClientId
+			creds["client_email"] = integration.Data.Credentials.ClientEmail
+			creds["private_key_id"] = integration.Data.Credentials.PrivateKeyId
+			d.Set("credentials", []map[string]string{creds})
+			d.Set("resource_level", integration.Data.IdType)
+			d.Set("resource_id", integration.Data.ID)
+			d.Set("subscription", integration.Data.SubscriptionName)
 
 			log.Printf("[INFO] Read GCP_AT integration with guid: %v\n", integration.IntgGuid)
 			return nil

--- a/lacework/resource_lacework_integration_gcp_cfg.go
+++ b/lacework/resource_lacework_integration_gcp_cfg.go
@@ -173,13 +173,18 @@ func resourceLaceworkIntegrationGcpCfgRead(d *schema.ResourceData, meta interfac
 			d.Set("name", integration.Name)
 			d.Set("intg_guid", integration.IntgGuid)
 			d.Set("enabled", integration.Enabled == 1)
-			d.Set("resource_level", integration.Data.IdType)
-			d.Set("resource_id", integration.Data.ID)
-
 			d.Set("created_or_updated_time", integration.CreatedOrUpdatedTime)
 			d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
 			d.Set("type_name", integration.TypeName)
 			d.Set("org_level", integration.IsOrg == 1)
+
+			creds := make(map[string]string)
+			creds["client_id"] = integration.Data.Credentials.ClientId
+			creds["client_email"] = integration.Data.Credentials.ClientEmail
+			creds["private_key_id"] = integration.Data.Credentials.PrivateKeyId
+			d.Set("credentials", []map[string]string{creds})
+			d.Set("resource_level", integration.Data.IdType)
+			d.Set("resource_id", integration.Data.ID)
 
 			log.Printf("[INFO] Read GCP_CFG integration with guid: %v\n", integration.IntgGuid)
 			return nil


### PR DESCRIPTION
When a user uses the Terraform Importer `terraform import resource.name ID`
the `Read()` function was not populating every field that the Lacework Server
returned, with this fix we are now updating all parameters in all integrations.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>