### PR TITLE
test: adds lacework_api_token acc tests

### DIFF
--- a/lacework/data_source_lacework_api_token_test.go
+++ b/lacework/data_source_lacework_api_token_test.go
@@ -1,0 +1,24 @@
+package lacework
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccApiToken(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+        data "lacework_api_token" "test" {}
+        `,
+				Check: resource.TestCheckResourceAttrSet(
+					"data.lacework_api_token.test", "token",
+				),
+			},
+		},
+	})
+}

--- a/lacework/provider_test.go
+++ b/lacework/provider_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-var testAccProvider *schema.Provider
-var testAccProviders map[string]terraform.ResourceProvider
+var (
+	testAccProvider  *schema.Provider
+	testAccProviders map[string]terraform.ResourceProvider
+)
 
 func init() {
 	testAccProvider = Provider().(*schema.Provider)

--- a/lacework/resource_lacework_integration_aws_ct_test.go
+++ b/lacework/resource_lacework_integration_aws_ct_test.go
@@ -127,7 +127,7 @@ func testAccIntegrationAwsCloudTrailConfig(enabled bool) string {
 resource "%s" "%s" {
     name = "integration test"
     enabled = %t
-    queue_url = %t
+    queue_url = %s
     credentials {
         role_arn = "%s"
         external_id = "%s"


### PR DESCRIPTION
```
➜  terraform-provider-lacework git:(master) ✗ export TESTARGS="-run TestAccApiToken"
➜  terraform-provider-lacework git:(master) ✗ make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccApiToken -timeout 120m
?   	github.com/lacework/terraform-provider-lacework	[no test files]
=== RUN   TestAccApiToken
--- PASS: TestAccApiToken (1.14s)
PASS
ok  	github.com/lacework/terraform-provider-lacework/lacework	1.438s

```
Signed-off-by: Salim Afiune Maya <afiune@lacework.net>