### PR TITLE
chore(version) Update CHANGELOG version from 0.1.0 to Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.1.0 (April 2020)
+# 0.1.0 (Unreleased)
 
 ## New Resources
 


### PR DESCRIPTION
`CHANGELOG.md` version will be automatically updated to `0.1.0` by Hashi bot and needs to be set to `Unreleased` until then.

Signed-off-by: Scott Ford <scott.ford@lacework.net>