### PR TITLE
feat(data-source): new lacework_agent_access_token

### DIFF
--- a/examples/data_source_lacework_agent_access_token/main.tf
+++ b/examples/data_source_lacework_agent_access_token/main.tf
@@ -1,0 +1,9 @@
+provider "lacework" {}
+
+data "lacework_agent_access_token" "k8s" {
+  name = "k8s-deployments"
+}
+
+output "lacework_agent_access_token" {
+  value = data.lacework_agent_access_token.k8s.token
+}

--- a/lacework/data_source_lacework_agent_access_token.go
+++ b/lacework/data_source_lacework_agent_access_token.go
@@ -1,0 +1,52 @@
+package lacework
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+func dataSourceLaceworkAgentAccessToken() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceLaceworkAgentAccessTokenRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"token": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func dataSourceLaceworkAgentAccessTokenRead(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	log.Printf("[INFO] Lookup agent access token.")
+	response, err := lacework.Agents.ListTokens()
+	if err != nil {
+		return err
+	}
+
+	lookupName := d.Get("name").(string)
+	for _, token := range response.Data {
+		if token.TokenAlias == lookupName {
+			log.Printf("[INFO] agent access token found. name=%s, description=%s, enabled=%t",
+				token.TokenAlias, token.Props.Description, token.Status())
+
+			d.Set("token", token.AccessToken)
+			d.SetId(token.TokenAlias)
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf("Agent access token with name '%s' was not found.", lookupName)
+}

--- a/lacework/data_source_lacework_api_token.go
+++ b/lacework/data_source_lacework_api_token.go
@@ -13,8 +13,9 @@ func dataSourceLaceworkApiToken() *schema.Resource {
 		Read: dataSourceLaceworkApiTokenRead,
 		Schema: map[string]*schema.Schema{
 			"token": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 		},
 	}

--- a/lacework/provider.go
+++ b/lacework/provider.go
@@ -66,7 +66,8 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"lacework_api_token": dataSourceLaceworkApiToken(),
+			"lacework_api_token":          dataSourceLaceworkApiToken(),
+			"lacework_agent_access_token": dataSourceLaceworkAgentAccessToken(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -286,23 +286,56 @@ update_changelog() {
 load_list_of_changes() {
   latest_version=$(find_latest_version)
   local _list_of_changes=$(git log --no-merges --pretty="* %s (%an)([%h](https://github.com/${org_name}/${project_name}/commit/%H))" ${latest_version}..master)
-  echo "## Features" > CHANGES.md
-  echo "$_list_of_changes" | grep "\* feat[:(]" >> CHANGES.md
-  echo "## Refactor" >> CHANGES.md
-  echo "$_list_of_changes" | grep "\* refactor[:(]" >> CHANGES.md
-  echo "## Performance Improvements" >> CHANGES.md
-  echo "$_list_of_changes" | grep "\* perf[:(]" >> CHANGES.md
-  echo "## Bug Fixes" >> CHANGES.md
-  echo "$_list_of_changes" | grep "\* fix[:(]" >> CHANGES.md
-  echo "## Documentation Updates" >> CHANGES.md
-  echo "$_list_of_changes" | grep "\* doc[:(]" >> CHANGES.md
-  echo "$_list_of_changes" | grep "\* docs[:(]" >> CHANGES.md
-  echo "## Other Changes" >> CHANGES.md
-  echo "$_list_of_changes" | grep "\* style[:(]" >> CHANGES.md
-  echo "$_list_of_changes" | grep "\* chore[:(]" >> CHANGES.md
-  echo "$_list_of_changes" | grep "\* build[:(]" >> CHANGES.md
-  echo "$_list_of_changes" | grep "\* ci[:(]" >> CHANGES.md
-  echo "$_list_of_changes" | grep "\* test[:(]" >> CHANGES.md
+
+  # init changes file
+  true > CHANGES.md
+
+  _feat=$(echo "$_list_of_changes" | grep "\* feat[:(]")
+  _refactor=$(echo "$_list_of_changes" | grep "\* refactor[:(]")
+  _perf=$(echo "$_list_of_changes" | grep "\* perf[:(]")
+  _fix=$(echo "$_list_of_changes" | grep "\* fix[:(]")
+  _doc=$(echo "$_list_of_changes" | grep "\* doc[:(]")
+  _docs=$(echo "$_list_of_changes" | grep "\* docs[:(]")
+  _style=$(echo "$_list_of_changes" | grep "\* style[:(]")
+  _chore=$(echo "$_list_of_changes" | grep "\* chore[:(]")
+  _build=$(echo "$_list_of_changes" | grep "\* build[:(]")
+  _ci=$(echo "$_list_of_changes" | grep "\* ci[:(]")
+  _test=$(echo "$_list_of_changes" | grep "\* test[:(]")
+
+  if [ "$_feat" != "" ]; then
+    echo "## Features" >> CHANGES.md
+    echo "$_feat" >> CHANGES.md
+  fi
+
+  if [ "$_refactor" != "" ]; then
+    echo "## Refactor" >> CHANGES.md
+    echo "$_refactor" >> CHANGES.md
+  fi
+
+  if [ "$_perf" != "" ]; then
+    echo "## Performance Improvements" >> CHANGES.md
+    echo "$_perf" >> CHANGES.md
+  fi
+
+  if [ "$_fix" != "" ]; then
+    echo "## Bug Fixes" >> CHANGES.md
+    echo "$_fix" >> CHANGES.md
+  fi
+
+  if [ "${_docs}${_doc}" != "" ]; then
+    echo "## Documentation Updates" >> CHANGES.md
+    if [ "$_doc" != "" ]; then echo "$_doc" >> CHANGES.md; fi
+    if [ "$_docs" != "" ]; then echo "$_docs" >> CHANGES.md; fi
+  fi
+
+  if [ "${_style}${_chore}${_build}${_ci}${_test}" != "" ]; then
+    echo "## Other Changes" >> CHANGES.md
+    if [ "$_style" != "" ]; then echo "$_style" >> CHANGES.md; fi
+    if [ "$_chore" != "" ]; then echo "$_chore" >> CHANGES.md; fi
+    if [ "$_build" != "" ]; then echo "$_build" >> CHANGES.md; fi
+    if [ "$_ci" != "" ]; then echo "$_ci" >> CHANGES.md; fi
+    if [ "$_test" != "" ]; then echo "$_test" >> CHANGES.md; fi
+  fi
 }
 
 generate_release_notes() {

--- a/website/docs/d/agent_access_token.html.markdown
+++ b/website/docs/d/agent_access_token.html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory: "Agents"
+layout: "lacework"
+page_title: "Lacework: lacework_agent_access_token"
+description: |-
+  Lookup agent access token.
+---
+
+# lacework\_agent\_access\_token
+
+Retrieve Lacework agent access tokens.
+
+-> **Note:** To list all agent access tokens in your Lacework account, use the
+	Lacework CLI command `lacework agent token list`. To install this tool follow
+	[this documentation](https://github.com/lacework/go-sdk/wiki/CLI-Documentation#installation).
+
+## Example Usage
+
+```hcl
+data "lacework_agent_access_token" "k8s" {
+  name = "k8s-deployments"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The agent access token name.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `token` - The agent access token.

--- a/website/lacework.erb
+++ b/website/lacework.erb
@@ -23,6 +23,16 @@
 
             </ul>
           </li>
+          <li>
+            <a href="#">Data Sources</a>
+            <ul class="nav nav-auto-expand">
+
+              <li>
+                <a href="/docs/providers/lacework/d/agent_access_token.html">lacework_agent_access_token</a>
+              </li>
+
+            </ul>
+          </li>
         </ul>
         </li>
 


### PR DESCRIPTION
To have parity with our resource `lacework_agent_access_token` we are
adding a new data source to retrieve Agent access tokens by looking up
for the Token Alias. (a.k.a Token Name)

# Example
```hcl
provider "lacework" {}

data "lacework_agent_access_token" "k8s" {
  name = "k8s-deployments"
}
```

Contributes https://github.com/lacework/terraform-provider-lacework/issues/41

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>