### PR TITLE
docs: adding more documentation about GCP resources

### DIFF
--- a/website/docs/r/integration_gcp_at.html.markdown
+++ b/website/docs/r/integration_gcp_at.html.markdown
@@ -27,6 +27,21 @@ resource "lacework_integration_gcp_at" "account_abc" {
 }
 ```
 
+## GCP Audit Trail Module Usage
+
+Lacework maintains a Terraform module that can be used to create and manage the necessary
+resources required from both, the cloud provider platform as well as the Lacework platform.
+
+Here is a basic usage of this module:
+```hcl
+module "config" {
+  source  = "lacework/audit-log/gcp"
+  version = "~> 0.1.1"
+}
+```
+
+To see the list of inputs, outputs and dependencies, visit the [Terraform registry page of this module](https://registry.terraform.io/modules/lacework/audit-log/gcp/latest).
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/r/integration_gcp_at.html.markdown
+++ b/website/docs/r/integration_gcp_at.html.markdown
@@ -30,7 +30,7 @@ resource "lacework_integration_gcp_at" "account_abc" {
 ## GCP Audit Trail Module Usage
 
 Lacework maintains a Terraform module that can be used to create and manage the necessary
-resources required from both, the cloud provider platform as well as the Lacework platform.
+resources required for both, the cloud provider platform as well as the Lacework platform.
 
 Here is a basic usage of this module:
 ```hcl

--- a/website/docs/r/integration_gcp_cfg.html.markdown
+++ b/website/docs/r/integration_gcp_cfg.html.markdown
@@ -28,7 +28,7 @@ resource "lacework_integration_gcp_cfg" "account_abc" {
 ## GCP Config Module Usage
 
 Lacework maintains a Terraform module that can be used to create and manage the necessary
-resources required from both, the cloud provider platform as well as the Lacework platform.
+resources required for both, the cloud provider platform as well as the Lacework platform.
 
 Here is a basic usage of this module:
 ```hcl

--- a/website/docs/r/integration_gcp_cfg.html.markdown
+++ b/website/docs/r/integration_gcp_cfg.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Use this resource to configure a GCP Config integration to analyze configuration compliance.
 
-~> **Note:** 
-
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/integration_gcp_cfg.html.markdown
+++ b/website/docs/r/integration_gcp_cfg.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Use this resource to configure a GCP Config integration to analyze configuration compliance.
 
+~> **Note:** 
+
 ## Example Usage
 
 ```hcl
@@ -24,6 +26,21 @@ resource "lacework_integration_gcp_cfg" "account_abc" {
   }
 }
 ```
+
+## GCP Config Module Usage
+
+Lacework maintains a Terraform module that can be used to create and manage the necessary
+resources required from both, the cloud provider platform as well as the Lacework platform.
+
+Here is a basic usage of this module:
+```hcl
+module "config" {
+  source  = "lacework/config/gcp"
+  version = "~> 0.1.1"
+}
+```
+
+To see the list of inputs, outputs and dependencies, visit the [Terraform registry page of this module](https://registry.terraform.io/modules/lacework/config/gcp/latest).
 
 ## Argument Reference
 

--- a/website/docs/r/integration_gcr.html.markdown
+++ b/website/docs/r/integration_gcr.html.markdown
@@ -27,6 +27,28 @@ resource "lacework_integration_gcr" "example" {
 }
 ```
 
+## Example Loading Credentials from Local File
+
+This example shows how to load a [service account key created](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys) using the Cloud Console
+or the `gcloud` command-line tool located on a local file on disk:
+
+```hcl
+locals {
+  gcr_credentials = jsondecode(file("/path/to/creds.json"))
+}
+
+resource "lacework_integration_gcr" "example" {
+  name            = "GRC Example"
+  registry_domain = "gcr.io"
+  credentials {
+    client_id      = local.gcr_credentials["client_id"]
+    client_email   = local.gcr_credentials["client_email"]
+    private_key_id = local.gcr_credentials["private_key_id"]
+    private_key    = local.gcr_credentials["private_key"]
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/r/integration_gcr.html.markdown
+++ b/website/docs/r/integration_gcr.html.markdown
@@ -27,7 +27,7 @@ resource "lacework_integration_gcr" "example" {
 }
 ```
 
-## Example Loading Credentials from Local File
+## Example Loading Credentials from Local File
 
 This example shows how to load a [service account key created](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys) using the Cloud Console
 or the `gcloud` command-line tool located on a local file on disk:
@@ -83,4 +83,3 @@ $ terraform import lacework_integration_gcr.example EXAMPLE_1234BAE1E42182964D23
 -> **Note:** To retreive the `INT_GUID` from existing integrations in your account, use the
 	Lacework CLI command `lacework integration list`. To install this tool follow
 	[this documentation](https://github.com/lacework/go-sdk/wiki/CLI-Documentation#installation).
-


### PR DESCRIPTION
A few documentation additions:

# docs: point gcp_cfg resources to tf modules

![image](https://user-images.githubusercontent.com/5712253/103626553-96472400-4ef9-11eb-8030-1d038c398f13.png)

# docs: point gcp_at resources to tf modules

![image](https://user-images.githubusercontent.com/5712253/103626408-626bfe80-4ef9-11eb-8cfb-873c8533d18b.png)

# docs: gcp example loading creds from file 

![image](https://user-images.githubusercontent.com/5712253/103626276-2fc20600-4ef9-11eb-9dd1-393650075841.png)


**JIRA: ALLY-256**