### PR TITLE
docs: fix closing curly brace in code snippet (S3 Data Export)

### DIFF
--- a/website/docs/r/alert_channel_aws_s3.html.markdown
+++ b/website/docs/r/alert_channel_aws_s3.html.markdown
@@ -32,6 +32,7 @@ resource "lacework_alert_channel_aws_s3" "data_export" {
     role_arn    = "arn:aws:iam::1234567890:role/lacework_iam_example_role"
     external_id = "12345"
   }
+}
 ```
 
 ## Argument Reference


### PR DESCRIPTION
This PR adds a missing curly brace in the code snippet for the S3 data export alert channel.


Signed-off-by: Scott Ford <scott.ford@lacework.net>