### PR TITLE
fix: deprecate docker_v2 attributes tag/label limits

### DIFF
--- a/examples/resource_lacework_integration_docker_v2/main.tf
+++ b/examples/resource_lacework_integration_docker_v2/main.tf
@@ -6,6 +6,8 @@ resource "lacework_integration_docker_v2" "example" {
   username        = "my-user"
   password        = "a-secret-password"
   ssl             = true
-  limit_by_tag    = "dev*"
-  limit_by_label  = "*label"
+
+  # These attributes are deprecated and will be removed in v1.0
+  limit_by_tag   = "dev*"
+  limit_by_label = "*label"
 }

--- a/lacework/resource_lacework_integration_docker_v2.go
+++ b/lacework/resource_lacework_integration_docker_v2.go
@@ -47,16 +47,22 @@ func resourceLaceworkIntegrationDockerV2() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+
+			// TODO @afiune remove these resources when we release 1.0
 			"limit_by_tag": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "*",
+				Type:       schema.TypeString,
+				Optional:   true,
+				Default:    "*",
+				Deprecated: "This attribute will be removed in version 1.0 of the Lacework provider",
 			},
 			"limit_by_label": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "*",
+				Type:       schema.TypeString,
+				Optional:   true,
+				Default:    "*",
+				Deprecated: "This attribute will be removed in version 1.0 of the Lacework provider",
 			},
+			// END TODO @afiune
+
 			"intg_guid": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/website/docs/r/integration_docker_v2.html.markdown
+++ b/website/docs/r/integration_docker_v2.html.markdown
@@ -56,8 +56,8 @@ The following arguments are supported:
 * `username` - (Required) The user that has at permissions to pull from the container registry the images to be assessed.
 * `password` - (Required) The password for the specified user.
 * `ssl` - (Optional) Enable or disable SSL communication. Defaults to `false`.
-* `limit_by_tag` - (Optional) An image tag to limit the assessment of images with matching tag. If you specify `limit_by_tag` and `limit_by_label` limits, they function as an `AND`. Supported field input are `mytext*mytext`, `mytext`, `mytext*`, or `mytext`. Only one `*` wildcard is supported. Defaults to `*`.
-* `limit_by_label` - (Optional) An image label to limit the assessment of images with matching label. If you specify `limit_by_tag` and `limit_by_label` limits, they function as an `AND`. Supported field input are `mytext*mytext`, `mytext`, `mytext*`, or `mytext`. Only one `*` wildcard is supported. Defaults to `*`.
+* `limit_by_tag` - (Optional, **Deprecated**) An image tag to limit the assessment of images with matching tag. If you specify `limit_by_tag` and `limit_by_label` limits, they function as an `AND`. Supported field input are `mytext*mytext`, `mytext`, `mytext*`, or `mytext`. Only one `*` wildcard is supported. Defaults to `*`. **This attribute will be removed in version 1.0 of the Lacework provider.**
+* `limit_by_label` - (Optional, **Deprecated**) An image label to limit the assessment of images with matching label. If you specify `limit_by_tag` and `limit_by_label` limits, they function as an `AND`. Supported field input are `mytext*mytext`, `mytext`, `mytext*`, or `mytext`. Only one `*` wildcard is supported. Defaults to `*`. **This attribute will be removed in version 1.0 of the Lacework provider.**
 * `enabled` - (Optional) The state of the external integration. Defaults to `true`.
 
 ## Import


### PR DESCRIPTION
We will remove these fields in v1.0, for now, we are just marking them
as deprecated so that our users can remove them.

JIRA: ALLY-533

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>