### PR TITLE
ci: pin Go tooling to specific versions

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,3 +1,8 @@
+# Tooling versions
+GOLANGCILINTVERSION?=1.23.8
+GOIMPORTSVERSION?=v0.1.2
+GOXVERSION?=v1.0.1
+
 TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 WEBSITE_REPO=github.com/hashicorp/terraform-website
@@ -5,7 +10,6 @@ PKG_NAME=lacework
 DIR=~/.terraform.d/plugins
 GO_CLIENT_VERSION=master
 COVERAGEOUT?=coverage.out
-GOLANGCILINTVERSION?=1.23.8
 GOFLAGS=-mod=vendor
 CGO_ENABLED?=0
 PACKAGENAME?=terraform-provider-lacework
@@ -114,8 +118,8 @@ ifeq (, $(shell which golangci-lint))
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v$(GOLANGCILINTVERSION)
 endif
 ifeq (, $(shell which goimports))
-	go get golang.org/x/tools/cmd/goimports
+	go get golang.org/x/tools/cmd/goimports@$(GOIMPORTSVERSION)
 endif
 ifeq (, $(shell which gox))
-	go get github.com/mitchellh/gox
+	go get github.com/mitchellh/gox@$(GOXVERSION)
 endif

--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,4 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.15.0 // indirect
-	golang.org/x/tools v0.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -316,8 +316,6 @@ github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LE
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/kyokomi/emoji/v2 v2.2.8/go.mod h1:JUcn42DTdsXJo1SWanHh4HKDEyPaR5CqkmoirZZP9qE=
-github.com/lacework/go-sdk v0.7.2-0.20210526210458-63097d55ae37 h1:7qBLUZfrzAT5M7xR43/8uftLaBgK9xsaT1wsg1iNztw=
-github.com/lacework/go-sdk v0.7.2-0.20210526210458-63097d55ae37/go.mod h1:oe8lEfxYZqOM8qZiygUvj/1BquxGsTEJqYSMuQTLXnQ=
 github.com/lacework/go-sdk v0.8.0 h1:mI19HQk/0VsYmIfBS0nIgf9Veq7dvutmGDwQjaOrnwk=
 github.com/lacework/go-sdk v0.8.0/go.mod h1:JvLoDrMTwgOJFgrghzKG78eqQ/qjcqRbTOqp/bDkaSE=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -666,7 +664,6 @@ golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200713011307-fd294ab11aed/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
-golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.2 h1:kRBLX7v7Af8W7Gdbbc908OJcdgtK8bOz9Uaj8/F1ACA=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -287,7 +287,6 @@ golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 # golang.org/x/tools v0.1.2
-## explicit
 golang.org/x/tools/cmd/goimports
 golang.org/x/tools/go/ast/astutil
 golang.org/x/tools/go/gcexportdata


### PR DESCRIPTION
# Fix

![tenor-14340061](https://user-images.githubusercontent.com/5712253/120940463-a9ddfd00-c6da-11eb-8560-f039d76b6a10.gif)
