### PR TITLE
ci: make clean-test directive

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -129,4 +129,4 @@ write-terraform-rc:
 	scripts/mirror-provider.sh
 
 clean-test:
-	find . \( -name ".terraform*" -o -name "terraform.tfstate*" \) -exec rm -rf {} \;
+	find . -name ".terraform*" -o -name "terraform.tfstate*" -exec rm -rf {} \;


### PR DESCRIPTION
This will avoid pipeline failures like:
```
make clean-test
find . \( -name ".terraform*" -o -name "terraform.tfstate*" \) -exec rm -rf {} \;
find: ./examples/resource_lacework_alert_channel_datadog/.terraform: No such file or directory
find: ./examples/resource_lacework_alert_channel_email/.terraform: No such file or directory
make: *** [clean-test] Error 1
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>