### PR TITLE
feat: Run Test Alert Channel during TF Create

### DIFF
--- a/examples/resource_lacework_alert_channel_datadog/main.tf
+++ b/examples/resource_lacework_alert_channel_datadog/main.tf
@@ -10,7 +10,7 @@ provider "lacework" {}
 
 variable "channel_name" {
   type    = string
-  default = "Datadog Alert Channel Test Example 2"
+  default = "Datadog Alert Channel Example"
 }
 
 resource "lacework_alert_channel_datadog" "example" {

--- a/examples/resource_lacework_alert_channel_datadog/main.tf
+++ b/examples/resource_lacework_alert_channel_datadog/main.tf
@@ -14,9 +14,9 @@ variable "channel_name" {
 }
 
 resource "lacework_alert_channel_datadog" "example" {
-  name            = var.channel_name
-  datadog_site    = "eu"
-  datadog_service = "Events Summary"
-  api_key         = "datadog-key"
-  disable_test    = true
+  name             = var.channel_name
+  datadog_site     = "eu"
+  datadog_service  = "Events Summary"
+  api_key          = "datadog-key"
+  test_integration = false
 }

--- a/examples/resource_lacework_alert_channel_datadog/main.tf
+++ b/examples/resource_lacework_alert_channel_datadog/main.tf
@@ -18,4 +18,5 @@ resource "lacework_alert_channel_datadog" "example" {
   datadog_site    = "eu"
   datadog_service = "Events Summary"
   api_key         = "datadog-key"
+  disable_test    = true
 }

--- a/examples/resource_lacework_alert_channel_datadog/main.tf
+++ b/examples/resource_lacework_alert_channel_datadog/main.tf
@@ -10,7 +10,7 @@ provider "lacework" {}
 
 variable "channel_name" {
   type    = string
-  default = "Datadog Alert Channel Example"
+  default = "Datadog Alert Channel Test Example 2"
 }
 
 resource "lacework_alert_channel_datadog" "example" {
@@ -18,5 +18,10 @@ resource "lacework_alert_channel_datadog" "example" {
   datadog_site     = "eu"
   datadog_service  = "Events Summary"
   api_key          = "datadog-key"
+
+  // test_integration input is used in this example only for testing
+  // purposes, it help us avoid sending a "test" request to the
+  // system we are integrating to. In production, this should remain
+  // turned on ("true") which is the default setting
   test_integration = false
 }

--- a/examples/resource_lacework_alert_channel_email/main.tf
+++ b/examples/resource_lacework_alert_channel_email/main.tf
@@ -16,4 +16,5 @@ variable "channel_name" {
 resource "lacework_alert_channel_email" "example" {
   name       = var.channel_name
   recipients = ["foo@example.com"]
+  test_integration = false
 }

--- a/examples/resource_lacework_alert_channel_email/main.tf
+++ b/examples/resource_lacework_alert_channel_email/main.tf
@@ -16,5 +16,10 @@ variable "channel_name" {
 resource "lacework_alert_channel_email" "example" {
   name       = var.channel_name
   recipients = ["foo@example.com"]
+
+  // test_integration input is used in this example only for testing
+  // purposes, it help us avoid sending a "test" request to the
+  // system we are integrating to. In production, this should remain
+  // turned on ("true") which is the default setting
   test_integration = false
 }

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,8 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/gruntwork-io/go-commons v0.8.0/go.mod h1:gtp0yTtIBExIZp7vyIV9I0XQkVwiQZze678hvDXof78=
-github.com/gruntwork-io/terratest v0.37.2 h1:qHf2y9YjshwVbkQ88RqoqvW9v7QSYXYlpCWomXFpkuw=
-github.com/gruntwork-io/terratest v0.37.2/go.mod h1:CSHpZNJdqYQ+TUrigM100jcahRUV5X6w7K2kZJ8iylY=
+github.com/gruntwork-io/terratest v0.36.8 h1:V4vuJSK23iTDGpu6mkLDUK9xSTWRblABX4RMI9kh+SU=
+github.com/gruntwork-io/terratest v0.36.8/go.mod h1:3zzDkmFBGDcSwQRaXS/LKnobwnff09oo5z/B6SVwRy8=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
@@ -664,9 +664,7 @@ github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6Ac
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
-github.com/vmihailenco/msgpack/v5 v5.2.0/go.mod h1:fEM7KuHcnm0GvDCztRpw9hV0PuoO2ciTismP6vjggcM=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=

--- a/lacework/alert_channel.go
+++ b/lacework/alert_channel.go
@@ -1,0 +1,18 @@
+package lacework
+
+import (
+	"github.com/lacework/go-sdk/api"
+)
+
+// TestAlertChannel tests the integration of an alert channel
+func TestAlertChannel(id string, meta interface{}) error {
+	lacework := meta.(*api.Client)
+	err := lacework.V2.AlertChannels.Test(id)
+
+	// rollback terraform create upon error testing integration
+	if err != nil {
+		_, err := lacework.Integrations.Delete(id)
+		return err
+	}
+	return nil
+}

--- a/lacework/alert_channel.go
+++ b/lacework/alert_channel.go
@@ -2,16 +2,16 @@ package lacework
 
 import (
 	"github.com/lacework/go-sdk/api"
+	"github.com/pkg/errors"
 )
 
-// TestAlertChannel tests the integration of an alert channel
-func TestAlertChannel(id string, meta interface{}) error {
-	lacework := meta.(*api.Client)
-	err := lacework.V2.AlertChannels.Test(id)
-
-	// rollback terraform create upon error testing integration
-	if err != nil {
-		_, err := lacework.Integrations.Delete(id)
+// VerifyAlertChannel tests the integration of an alert channel
+func VerifyAlertChannel(id string, lacework *api.Client) error {
+	if err := lacework.V2.AlertChannels.Test(id); err != nil {
+		// rollback terraform create upon error testing integration
+		if _, deleteErr := lacework.Integrations.Delete(id); deleteErr != nil {
+			return errors.Wrapf(err, "Unable to rollback changes: %v", deleteErr)
+		}
 		return err
 	}
 	return nil

--- a/lacework/alert_channel.go
+++ b/lacework/alert_channel.go
@@ -1,16 +1,17 @@
 package lacework
 
 import (
-	"github.com/lacework/go-sdk/api"
 	"github.com/pkg/errors"
+
+	"github.com/lacework/go-sdk/api"
 )
 
 // VerifyAlertChannel tests the integration of an alert channel
 func VerifyAlertChannel(id string, lacework *api.Client) error {
 	if err := lacework.V2.AlertChannels.Test(id); err != nil {
 		// rollback terraform create upon error testing integration
-		if _, deleteErr := lacework.Integrations.Delete(id); deleteErr != nil {
-			return errors.Wrapf(err, "Unable to rollback changes: %v", deleteErr)
+		if deleteErr := lacework.V2.AlertChannels.Delete(id); deleteErr != nil {
+			return errors.Wrapf(deleteErr, "Unable to rollback changes: %v", err)
 		}
 		return err
 	}

--- a/lacework/resource_lacework_alert_channel_aws_cloudwatch.go
+++ b/lacework/resource_lacework_alert_channel_aws_cloudwatch.go
@@ -55,6 +55,12 @@ func resourceLaceworkAlertChannelAwsCloudWatch() *schema.Resource {
 					}
 				},
 			},
+			"test_integration": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether to test the integration of an alert channel upon creation",
+			},
 			"created_or_updated_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -84,6 +90,7 @@ func resourceLaceworkAlertChannelAwsCloudWatchCreate(d *schema.ResourceData, met
 				IssueGrouping: d.Get("group_issues_by").(string),
 			},
 		)
+		testIntegration = d.Get("test_integration").(bool)
 	)
 	if !d.Get("enabled").(bool) {
 		alert.Enabled = 0
@@ -111,6 +118,15 @@ func resourceLaceworkAlertChannelAwsCloudWatchCreate(d *schema.ResourceData, met
 	d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
+
+	if testIntegration {
+		log.Printf("[INFO] Testing %s integration for guid:%s\n", api.DatadogChannelIntegration, d.Id())
+		err := VerifyAlertChannel(d.Id(), lacework)
+		if err != nil {
+			return err
+		}
+		log.Printf("[INFO] Tested %s integration with guid: %s successfully \n", api.DatadogChannelIntegration, d.Id())
+	}
 
 	log.Printf("[INFO] Created %s integration with guid: %v\n", api.AwsCloudWatchIntegration, integration.IntgGuid)
 	return nil

--- a/lacework/resource_lacework_alert_channel_aws_s3.go
+++ b/lacework/resource_lacework_alert_channel_aws_s3.go
@@ -58,6 +58,12 @@ func resourceLaceworkAlertChannelAwsS3() *schema.Resource {
 					},
 				},
 			},
+			"test_integration": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether to test the integration of an alert channel upon creation",
+			},
 			"created_or_updated_by": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -86,6 +92,7 @@ func resourceLaceworkAlertChannelAwsS3Create(d *schema.ResourceData, meta interf
 				},
 			},
 		)
+		testIntegration = d.Get("test_integration").(bool)
 	)
 	if !d.Get("enabled").(bool) {
 		s3.Enabled = 0
@@ -112,6 +119,15 @@ func resourceLaceworkAlertChannelAwsS3Create(d *schema.ResourceData, meta interf
 	d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
+
+	if testIntegration {
+		log.Printf("[INFO] Testing %s integration for guid:%s\n", api.DatadogChannelIntegration, d.Id())
+		err := VerifyAlertChannel(d.Id(), lacework)
+		if err != nil {
+			return err
+		}
+		log.Printf("[INFO] Tested %s integration with guid: %s successfully \n", api.DatadogChannelIntegration, d.Id())
+	}
 
 	log.Printf("[INFO] Created %s integration with guid: %v\n", api.AwsS3ChannelIntegration, integration.IntgGuid)
 	return nil

--- a/lacework/resource_lacework_alert_channel_cisco_webex.go
+++ b/lacework/resource_lacework_alert_channel_cisco_webex.go
@@ -37,6 +37,12 @@ func resourceLaceworkAlertChannelCiscoWebex() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"test_integration": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether to test the integration of an alert channel upon creation",
+			},
 			"created_or_updated_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -65,6 +71,7 @@ func resourceLaceworkAlertChannelCiscoWebexCreate(d *schema.ResourceData, meta i
 				WebhookURL: d.Get("webhook_url").(string),
 			},
 		)
+		testIntegration = d.Get("test_integration").(bool)
 	)
 	if !d.Get("enabled").(bool) {
 		webex.Enabled = 0
@@ -91,6 +98,15 @@ func resourceLaceworkAlertChannelCiscoWebexCreate(d *schema.ResourceData, meta i
 	d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
+
+	if testIntegration {
+		log.Printf("[INFO] Testing %s integration for guid:%s\n", api.DatadogChannelIntegration, d.Id())
+		err := VerifyAlertChannel(d.Id(), lacework)
+		if err != nil {
+			return err
+		}
+		log.Printf("[INFO] Tested %s integration with guid: %s successfully \n", api.DatadogChannelIntegration, d.Id())
+	}
 
 	log.Printf("[INFO] Created %s integration with guid: %v\n", api.CiscoWebexChannelIntegration, integration.IntgGuid)
 	return nil

--- a/lacework/resource_lacework_alert_channel_email.go
+++ b/lacework/resource_lacework_alert_channel_email.go
@@ -44,6 +44,12 @@ func resourceLaceworkAlertChannelEmail() *schema.Resource {
 					},
 				},
 			},
+			"test_integration": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether to test the integration of an alert channel upon creation",
+			},
 			"intg_guid": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -79,6 +85,7 @@ func resourceLaceworkAlertChannelEmailCreate(d *schema.ResourceData, meta interf
 				},
 			},
 		)
+		testIntegration = d.Get("test_integration").(bool)
 	)
 	if !d.Get("enabled").(bool) {
 		emailAlertChan.Enabled = 0
@@ -98,6 +105,15 @@ func resourceLaceworkAlertChannelEmailCreate(d *schema.ResourceData, meta interf
 	d.Set("created_or_updated_by", response.Data.CreatedOrUpdatedBy)
 	d.Set("type_name", response.Data.Type)
 	d.Set("org_level", response.Data.IsOrg == 1)
+
+	if testIntegration {
+		log.Printf("[INFO] Testing %s integration for guid:%s\n", api.DatadogChannelIntegration, d.Id())
+		err := VerifyAlertChannel(d.Id(), lacework)
+		if err != nil {
+			return err
+		}
+		log.Printf("[INFO] Tested %s integration with guid: %s successfully \n", api.DatadogChannelIntegration, d.Id())
+	}
 
 	log.Printf("[INFO] Created %s integration with guid: %s\n", api.EmailUserAlertChannel, response.Data.IntgGuid)
 	return nil

--- a/lacework/resource_lacework_alert_channel_gcp_pub_sub.go
+++ b/lacework/resource_lacework_alert_channel_gcp_pub_sub.go
@@ -98,6 +98,12 @@ func resourceLaceworkAlertChannelGcpPubSub() *schema.Resource {
 					},
 				},
 			},
+			"test_integration": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether to test the integration of an alert channel upon creation",
+			},
 			"created_or_updated_by": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -130,6 +136,7 @@ func resourceLaceworkAlertChannelGcpPubSubCreate(d *schema.ResourceData, meta in
 				},
 			},
 		)
+		testIntegration = d.Get("test_integration").(bool)
 	)
 	if !d.Get("enabled").(bool) {
 		s3.Enabled = 0
@@ -156,6 +163,15 @@ func resourceLaceworkAlertChannelGcpPubSubCreate(d *schema.ResourceData, meta in
 	d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
+
+	if testIntegration {
+		log.Printf("[INFO] Testing %s integration for guid:%s\n", api.DatadogChannelIntegration, d.Id())
+		err := VerifyAlertChannel(d.Id(), lacework)
+		if err != nil {
+			return err
+		}
+		log.Printf("[INFO] Tested %s integration with guid: %s successfully \n", api.DatadogChannelIntegration, d.Id())
+	}
 
 	log.Printf("[INFO] Created %s integration with guid: %v\n", api.GcpPubSubChannelIntegration, integration.IntgGuid)
 	return nil

--- a/lacework/resource_lacework_alert_channel_jira_cloud.go
+++ b/lacework/resource_lacework_alert_channel_jira_cloud.go
@@ -78,6 +78,12 @@ func resourceLaceworkAlertChannelJiraCloud() *schema.Resource {
 					}
 				},
 			},
+			"test_integration": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether to test the integration of an alert channel upon creation",
+			},
 			"created_or_updated_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -110,6 +116,7 @@ func resourceLaceworkAlertChannelJiraCloudCreate(d *schema.ResourceData, meta in
 			Username:      d.Get("username").(string),
 			ApiToken:      d.Get("api_token").(string),
 		}
+		testIntegration = d.Get("test_integration").(bool)
 	)
 
 	if len(customTemplateJSON) != 0 {
@@ -143,6 +150,15 @@ func resourceLaceworkAlertChannelJiraCloudCreate(d *schema.ResourceData, meta in
 	d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
+
+	if testIntegration {
+		log.Printf("[INFO] Testing %s integration for guid:%s\n", api.DatadogChannelIntegration, d.Id())
+		err := VerifyAlertChannel(d.Id(), lacework)
+		if err != nil {
+			return err
+		}
+		log.Printf("[INFO] Tested %s integration with guid: %s successfully \n", api.DatadogChannelIntegration, d.Id())
+	}
 
 	log.Printf("[INFO] Created %s integration with guid: %v\n", api.JiraIntegration, integration.IntgGuid)
 	return nil

--- a/lacework/resource_lacework_alert_channel_jira_server.go
+++ b/lacework/resource_lacework_alert_channel_jira_server.go
@@ -77,6 +77,12 @@ func resourceLaceworkAlertChannelJiraServer() *schema.Resource {
 					}
 				},
 			},
+			"test_integration": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether to test the integration of an alert channel upon creation",
+			},
 			"created_or_updated_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -109,6 +115,7 @@ func resourceLaceworkAlertChannelJiraServerCreate(d *schema.ResourceData, meta i
 			Username:      d.Get("username").(string),
 			Password:      d.Get("password").(string),
 		}
+		testIntegration = d.Get("test_integration").(bool)
 	)
 
 	if len(customTemplateJSON) != 0 {
@@ -142,6 +149,15 @@ func resourceLaceworkAlertChannelJiraServerCreate(d *schema.ResourceData, meta i
 	d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
+
+	if testIntegration {
+		log.Printf("[INFO] Testing %s integration for guid:%s\n", api.DatadogChannelIntegration, d.Id())
+		err := VerifyAlertChannel(d.Id(), lacework)
+		if err != nil {
+			return err
+		}
+		log.Printf("[INFO] Tested %s integration with guid: %s successfully \n", api.DatadogChannelIntegration, d.Id())
+	}
 
 	log.Printf("[INFO] Created %s integration with guid: %v\n", api.JiraIntegration, integration.IntgGuid)
 	return nil

--- a/lacework/resource_lacework_alert_channel_microsoft_teams.go
+++ b/lacework/resource_lacework_alert_channel_microsoft_teams.go
@@ -37,6 +37,12 @@ func resourceLaceworkAlertChannelMicrosoftTeams() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"test_integration": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether to test the integration of an alert channel upon creation",
+			},
 			"created_or_updated_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -65,6 +71,7 @@ func resourceLaceworkAlertChannelMicrosoftTeamsCreate(d *schema.ResourceData, me
 				WebhookURL: d.Get("webhook_url").(string),
 			},
 		)
+		testIntegration = d.Get("test_integration").(bool)
 	)
 	if !d.Get("enabled").(bool) {
 		microsoftTeams.Enabled = 0
@@ -91,6 +98,15 @@ func resourceLaceworkAlertChannelMicrosoftTeamsCreate(d *schema.ResourceData, me
 	d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
+
+	if testIntegration {
+		log.Printf("[INFO] Testing %s integration for guid:%s\n", api.DatadogChannelIntegration, d.Id())
+		err := VerifyAlertChannel(d.Id(), lacework)
+		if err != nil {
+			return err
+		}
+		log.Printf("[INFO] Tested %s integration with guid: %s successfully \n", api.DatadogChannelIntegration, d.Id())
+	}
 
 	log.Printf("[INFO] Created %s integration with guid: %v\n", api.MicrosoftTeamsChannelIntegration, integration.IntgGuid)
 	return nil

--- a/lacework/resource_lacework_alert_channel_newrelic.go
+++ b/lacework/resource_lacework_alert_channel_newrelic.go
@@ -41,6 +41,12 @@ func resourceLaceworkAlertChannelNewRelic() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"test_integration": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether to test the integration of an alert channel upon creation",
+			},
 			"created_or_updated_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -70,6 +76,7 @@ func resourceLaceworkAlertChannelNewRelicCreate(d *schema.ResourceData, meta int
 				InsertKey: d.Get("insert_key").(string),
 			},
 		)
+		testIntegration = d.Get("test_integration").(bool)
 	)
 	if !d.Get("enabled").(bool) {
 		relic.Enabled = 0
@@ -96,6 +103,15 @@ func resourceLaceworkAlertChannelNewRelicCreate(d *schema.ResourceData, meta int
 	d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
+
+	if testIntegration {
+		log.Printf("[INFO] Testing %s integration for guid:%s\n", api.DatadogChannelIntegration, d.Id())
+		err := VerifyAlertChannel(d.Id(), lacework)
+		if err != nil {
+			return err
+		}
+		log.Printf("[INFO] Tested %s integration with guid: %s successfully \n", api.DatadogChannelIntegration, d.Id())
+	}
 
 	log.Printf("[INFO] Created %s integration with guid: %v\n", api.NewRelicChannelIntegration, integration.IntgGuid)
 	return nil

--- a/lacework/resource_lacework_alert_channel_qradar.go
+++ b/lacework/resource_lacework_alert_channel_qradar.go
@@ -66,6 +66,12 @@ func resourceLaceworkAlertChannelQRadar() *schema.Resource {
 					return
 				},
 			},
+			"test_integration": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether to test the integration of an alert channel upon creation",
+			},
 			"created_or_updated_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -98,6 +104,7 @@ func resourceLaceworkAlertChannelQRadarCreate(d *schema.ResourceData, meta inter
 				CommunicationType: comm,
 			},
 		)
+		testIntegration = d.Get("test_integration").(bool)
 	)
 	if !d.Get("enabled").(bool) {
 		qradar.Enabled = 0
@@ -124,6 +131,15 @@ func resourceLaceworkAlertChannelQRadarCreate(d *schema.ResourceData, meta inter
 	d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
+
+	if testIntegration {
+		log.Printf("[INFO] Testing %s integration for guid:%s\n", api.DatadogChannelIntegration, d.Id())
+		err := VerifyAlertChannel(d.Id(), lacework)
+		if err != nil {
+			return err
+		}
+		log.Printf("[INFO] Tested %s integration with guid: %s successfully \n", api.DatadogChannelIntegration, d.Id())
+	}
 
 	log.Printf("[INFO] Created %s integration with guid: %v\n", api.QRadarChannelIntegration, integration.IntgGuid)
 	return nil

--- a/lacework/resource_lacework_alert_channel_service_now.go
+++ b/lacework/resource_lacework_alert_channel_service_now.go
@@ -67,6 +67,12 @@ func resourceLaceworkAlertChannelServiceNow() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"test_integration": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether to test the integration of an alert channel upon creation",
+			},
 			"created_or_updated_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -97,6 +103,7 @@ func resourceLaceworkAlertChannelServiceNowCreate(d *schema.ResourceData, meta i
 			Password:      d.Get("password").(string),
 			IssueGrouping: d.Get("issue_grouping").(string),
 		}
+		testIntegration = d.Get("test_integration").(bool)
 	)
 
 	if len(customTemplateJSON) != 0 {
@@ -129,6 +136,15 @@ func resourceLaceworkAlertChannelServiceNowCreate(d *schema.ResourceData, meta i
 	d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
+
+	if testIntegration {
+		log.Printf("[INFO] Testing %s integration for guid:%s\n", api.DatadogChannelIntegration, d.Id())
+		err := VerifyAlertChannel(d.Id(), lacework)
+		if err != nil {
+			return err
+		}
+		log.Printf("[INFO] Tested %s integration with guid: %s successfully \n", api.DatadogChannelIntegration, d.Id())
+	}
 
 	log.Printf("[INFO] Created %s integration with guid: %v\n", api.ServiceNowChannelIntegration, integration.IntgGuid)
 	return nil

--- a/lacework/resource_lacework_alert_channel_splunk.go
+++ b/lacework/resource_lacework_alert_channel_splunk.go
@@ -78,6 +78,12 @@ func resourceLaceworkAlertChannelSplunk() *schema.Resource {
 					},
 				},
 			},
+			"test_integration": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether to test the integration of an alert channel upon creation",
+			},
 			"created_or_updated_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -114,6 +120,7 @@ func resourceLaceworkAlertChannelSplunkCreate(d *schema.ResourceData, meta inter
 				},
 			},
 		)
+		testIntegration = d.Get("test_integration").(bool)
 	)
 	if !d.Get("enabled").(bool) {
 		splunk.Enabled = 0
@@ -140,6 +147,15 @@ func resourceLaceworkAlertChannelSplunkCreate(d *schema.ResourceData, meta inter
 	d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
+
+	if testIntegration {
+		log.Printf("[INFO] Testing %s integration for guid:%s\n", api.DatadogChannelIntegration, d.Id())
+		err := VerifyAlertChannel(d.Id(), lacework)
+		if err != nil {
+			return err
+		}
+		log.Printf("[INFO] Tested %s integration with guid: %s successfully \n", api.DatadogChannelIntegration, d.Id())
+	}
 
 	log.Printf("[INFO] Created %s integration with guid: %v\n", api.SplunkIntegration, integration.IntgGuid)
 	return nil

--- a/lacework/resource_lacework_alert_channel_victorops.go
+++ b/lacework/resource_lacework_alert_channel_victorops.go
@@ -37,6 +37,12 @@ func resourceLaceworkAlertChannelVictorOps() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"test_integration": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether to test the integration of an alert channel upon creation",
+			},
 			"created_or_updated_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -65,6 +71,7 @@ func resourceLaceworkAlertChannelVictorOpsCreate(d *schema.ResourceData, meta in
 				WebhookURL: d.Get("webhook_url").(string),
 			},
 		)
+		testIntegration = d.Get("test_integration").(bool)
 	)
 	if !d.Get("enabled").(bool) {
 		victor.Enabled = 0
@@ -91,6 +98,15 @@ func resourceLaceworkAlertChannelVictorOpsCreate(d *schema.ResourceData, meta in
 	d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
+
+	if testIntegration {
+		log.Printf("[INFO] Testing %s integration for guid:%s\n", api.DatadogChannelIntegration, d.Id())
+		err := VerifyAlertChannel(d.Id(), lacework)
+		if err != nil {
+			return err
+		}
+		log.Printf("[INFO] Tested %s integration with guid: %s successfully \n", api.DatadogChannelIntegration, d.Id())
+	}
 
 	log.Printf("[INFO] Created %s integration with guid: %v\n", api.VictorOpsChannelIntegration, integration.IntgGuid)
 	return nil

--- a/lacework/resource_lacework_alert_channel_webhook.go
+++ b/lacework/resource_lacework_alert_channel_webhook.go
@@ -37,6 +37,12 @@ func resourceLaceworkAlertChannelWebhook() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"test_integration": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether to test the integration of an alert channel upon creation",
+			},
 			"created_or_updated_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -65,6 +71,7 @@ func resourceLaceworkAlertChannelWebhookCreate(d *schema.ResourceData, meta inte
 				WebhookUrl: d.Get("webhook_url").(string),
 			},
 		)
+		testIntegration = d.Get("test_integration").(bool)
 	)
 	if !d.Get("enabled").(bool) {
 		webhook.Enabled = 0
@@ -91,6 +98,15 @@ func resourceLaceworkAlertChannelWebhookCreate(d *schema.ResourceData, meta inte
 	d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
+
+	if testIntegration {
+		log.Printf("[INFO] Testing %s integration for guid:%s\n", api.DatadogChannelIntegration, d.Id())
+		err := VerifyAlertChannel(d.Id(), lacework)
+		if err != nil {
+			return err
+		}
+		log.Printf("[INFO] Tested %s integration with guid: %s successfully \n", api.DatadogChannelIntegration, d.Id())
+	}
 
 	log.Printf("[INFO] Created %s integration with guid: %v\n", api.WebhookIntegration, integration.IntgGuid)
 	return nil

--- a/vendor/github.com/lacework/go-sdk/api/alert_channels.go
+++ b/vendor/github.com/lacework/go-sdk/api/alert_channels.go
@@ -52,7 +52,7 @@ type AlertChannelsService struct {
 //     },
 //   )
 //
-//   client.V2.AlertChannels.Create(emailAlertChan)
+//   client.V2.AlertChannels.Creates(emailAlertChan)
 //
 func NewAlertChannel(name string, iType alertChannelType, data interface{}) AlertChannelRaw {
 	return AlertChannelRaw{


### PR DESCRIPTION
https://lacework.atlassian.net/browse/ALLY-331

*Example of adding Test Integration to TF Create of Alert Channels

Alert Channel resources run "Test Integration" `v2/AlertChannels/IntGuid/test` during Terraform Create.
The resource is deleted upon failing the Test.

Skip running the Test Integration with `test_integration` flag

```
resource "lacework_alert_channel_datadog" "example" {
  name            = var.channel_name
  ...
  test_integration    = true
}
```

Signed-off-by: Darren Murray <darren.murray@lacework.net>