### PR TITLE
refactor: test Alert Channels on create and modify

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -129,4 +129,5 @@ write-terraform-rc:
 	scripts/mirror-provider.sh
 
 clean-test:
-	find . -name ".terraform*" -o -name "terraform.tfstate*" -exec rm -rf {} \;
+	find . -name ".terraform*" -type f -exec rm -rf {} \;
+	find . -name "terraform.tfstate*" -type f -exec rm -rf {} \;

--- a/lacework/alert_channel.go
+++ b/lacework/alert_channel.go
@@ -6,8 +6,9 @@ import (
 	"github.com/lacework/go-sdk/api"
 )
 
-// VerifyAlertChannel tests the integration of an alert channel
-func VerifyAlertChannel(id string, lacework *api.Client) error {
+// VerifyAlertChannelAndRollback will test the integration of an alert channel,
+// if the test is not successful, it will remove the alert channel (rollback)
+func VerifyAlertChannelAndRollback(id string, lacework *api.Client) error {
 	if err := lacework.V2.AlertChannels.Test(id); err != nil {
 		// rollback terraform create upon error testing integration
 		if deleteErr := lacework.V2.AlertChannels.Delete(id); deleteErr != nil {

--- a/lacework/resource_lacework_alert_channel_gcp_pub_sub.go
+++ b/lacework/resource_lacework_alert_channel_gcp_pub_sub.go
@@ -102,7 +102,7 @@ func resourceLaceworkAlertChannelGcpPubSub() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
-				Description: "Whether to test the integration of an alert channel upon creation",
+				Description: "Whether to test the integration of an alert channel upon creation and modification",
 			},
 			"created_or_updated_by": {
 				Type:     schema.TypeString,
@@ -136,7 +136,6 @@ func resourceLaceworkAlertChannelGcpPubSubCreate(d *schema.ResourceData, meta in
 				},
 			},
 		)
-		testIntegration = d.Get("test_integration").(bool)
 	)
 	if !d.Get("enabled").(bool) {
 		s3.Enabled = 0
@@ -164,23 +163,22 @@ func resourceLaceworkAlertChannelGcpPubSubCreate(d *schema.ResourceData, meta in
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
 
-	if testIntegration {
-		log.Printf("[INFO] Testing %s integration for guid:%s\n", api.DatadogChannelIntegration, d.Id())
-		err := VerifyAlertChannel(d.Id(), lacework)
-		if err != nil {
+	if d.Get("test_integration").(bool) {
+		log.Printf("[INFO] Testing %s integration for guid %s\n", api.GcpPubSubChannelIntegration, d.Id())
+		if err := VerifyAlertChannelAndRollback(d.Id(), lacework); err != nil {
 			return err
 		}
-		log.Printf("[INFO] Tested %s integration with guid: %s successfully \n", api.DatadogChannelIntegration, d.Id())
+		log.Printf("[INFO] Tested %s integration with guid %s successfully\n", api.GcpPubSubChannelIntegration, d.Id())
 	}
 
-	log.Printf("[INFO] Created %s integration with guid: %v\n", api.GcpPubSubChannelIntegration, integration.IntgGuid)
+	log.Printf("[INFO] Created %s integration with guid %s\n", api.GcpPubSubChannelIntegration, integration.IntgGuid)
 	return nil
 }
 
 func resourceLaceworkAlertChannelGcpPubSubRead(d *schema.ResourceData, meta interface{}) error {
 	lacework := meta.(*api.Client)
 
-	log.Printf("[INFO] Reading %s integration with guid: %v\n", api.GcpPubSubChannelIntegration, d.Id())
+	log.Printf("[INFO] Reading %s integration with guid %s\n", api.GcpPubSubChannelIntegration, d.Id())
 	response, err := lacework.Integrations.GetGcpPubSubAlertChannel(d.Id())
 	if err != nil {
 		return err
@@ -207,7 +205,7 @@ func resourceLaceworkAlertChannelGcpPubSubRead(d *schema.ResourceData, meta inte
 
 			d.Set("credentials", []map[string]string{creds})
 
-			log.Printf("[INFO] Read %s integration with guid: %v\n",
+			log.Printf("[INFO] Read %s integration with guid %s\n",
 				api.GcpPubSubChannelIntegration, integration.IntgGuid)
 			return nil
 		}
@@ -262,20 +260,28 @@ func resourceLaceworkAlertChannelGcpPubSubUpdate(d *schema.ResourceData, meta in
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
 
-	log.Printf("[INFO] Updated %s integration with guid: %v\n", api.GcpPubSubChannelIntegration, d.Id())
+	if d.Get("test_integration").(bool) {
+		log.Printf("[INFO] Testing %s integration for guid %s\n", api.GcpPubSubChannelIntegration, d.Id())
+		if err := lacework.V2.AlertChannels.Test(d.Id()); err != nil {
+			return err
+		}
+		log.Printf("[INFO] Tested %s integration with guid %s successfully\n", api.GcpPubSubChannelIntegration, d.Id())
+	}
+
+	log.Printf("[INFO] Updated %s integration with guid %s\n", api.GcpPubSubChannelIntegration, d.Id())
 	return nil
 }
 
 func resourceLaceworkAlertChannelGcpPubSubDelete(d *schema.ResourceData, meta interface{}) error {
 	lacework := meta.(*api.Client)
 
-	log.Printf("[INFO] Deleting %s integration with guid: %v\n", api.GcpPubSubChannelIntegration, d.Id())
+	log.Printf("[INFO] Deleting %s integration with guid %s\n", api.GcpPubSubChannelIntegration, d.Id())
 	_, err := lacework.Integrations.Delete(d.Id())
 	if err != nil {
 		return err
 	}
 
-	log.Printf("[INFO] Deleted %s integration with guid: %v\n", api.GcpPubSubChannelIntegration, d.Id())
+	log.Printf("[INFO] Deleted %s integration with guid %s\n", api.GcpPubSubChannelIntegration, d.Id())
 	return nil
 }
 

--- a/lacework/resource_lacework_alert_channel_jira_server.go
+++ b/lacework/resource_lacework_alert_channel_jira_server.go
@@ -81,7 +81,7 @@ func resourceLaceworkAlertChannelJiraServer() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
-				Description: "Whether to test the integration of an alert channel upon creation",
+				Description: "Whether to test the integration of an alert channel upon creation and modification",
 			},
 			"created_or_updated_time": {
 				Type:     schema.TypeString,
@@ -115,7 +115,6 @@ func resourceLaceworkAlertChannelJiraServerCreate(d *schema.ResourceData, meta i
 			Username:      d.Get("username").(string),
 			Password:      d.Get("password").(string),
 		}
-		testIntegration = d.Get("test_integration").(bool)
 	)
 
 	if len(customTemplateJSON) != 0 {
@@ -150,23 +149,22 @@ func resourceLaceworkAlertChannelJiraServerCreate(d *schema.ResourceData, meta i
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
 
-	if testIntegration {
-		log.Printf("[INFO] Testing %s integration for guid:%s\n", api.DatadogChannelIntegration, d.Id())
-		err := VerifyAlertChannel(d.Id(), lacework)
-		if err != nil {
+	if d.Get("test_integration").(bool) {
+		log.Printf("[INFO] Testing %s integration for guid %s\n", api.JiraIntegration, d.Id())
+		if err := VerifyAlertChannelAndRollback(d.Id(), lacework); err != nil {
 			return err
 		}
-		log.Printf("[INFO] Tested %s integration with guid: %s successfully \n", api.DatadogChannelIntegration, d.Id())
+		log.Printf("[INFO] Tested %s integration with guid %s successfully\n", api.JiraIntegration, d.Id())
 	}
 
-	log.Printf("[INFO] Created %s integration with guid: %v\n", api.JiraIntegration, integration.IntgGuid)
+	log.Printf("[INFO] Created %s integration with guid %s\n", api.JiraIntegration, integration.IntgGuid)
 	return nil
 }
 
 func resourceLaceworkAlertChannelJiraServerRead(d *schema.ResourceData, meta interface{}) error {
 	lacework := meta.(*api.Client)
 
-	log.Printf("[INFO] Reading %s integration with guid: %v\n", api.JiraIntegration, d.Id())
+	log.Printf("[INFO] Reading %s integration with guid %s\n", api.JiraIntegration, d.Id())
 	response, err := lacework.Integrations.GetJiraAlertChannel(d.Id())
 	if err != nil {
 		return err
@@ -196,7 +194,7 @@ func resourceLaceworkAlertChannelJiraServerRead(d *schema.ResourceData, meta int
 				d.Set("custom_template_file", customTemplateString)
 			}
 
-			log.Printf("[INFO] Read %s integration with guid: %v\n",
+			log.Printf("[INFO] Read %s integration with guid %s\n",
 				api.JiraIntegration, integration.IntgGuid)
 			return nil
 		}
@@ -253,19 +251,27 @@ func resourceLaceworkAlertChannelJiraServerUpdate(d *schema.ResourceData, meta i
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
 
-	log.Printf("[INFO] Updated %s integration with guid: %v\n", api.JiraIntegration, d.Id())
+	if d.Get("test_integration").(bool) {
+		log.Printf("[INFO] Testing %s integration for guid %s\n", api.JiraIntegration, d.Id())
+		if err := lacework.V2.AlertChannels.Test(d.Id()); err != nil {
+			return err
+		}
+		log.Printf("[INFO] Tested %s integration with guid %s successfully\n", api.JiraIntegration, d.Id())
+	}
+
+	log.Printf("[INFO] Updated %s integration with guid %s\n", api.JiraIntegration, d.Id())
 	return nil
 }
 
 func resourceLaceworkAlertChannelJiraServerDelete(d *schema.ResourceData, meta interface{}) error {
 	lacework := meta.(*api.Client)
 
-	log.Printf("[INFO] Deleting %s integration with guid: %v\n", api.JiraIntegration, d.Id())
+	log.Printf("[INFO] Deleting %s integration with guid %s\n", api.JiraIntegration, d.Id())
 	_, err := lacework.Integrations.Delete(d.Id())
 	if err != nil {
 		return err
 	}
 
-	log.Printf("[INFO] Deleted %s integration with guid: %v\n", api.JiraIntegration, d.Id())
+	log.Printf("[INFO] Deleted %s integration with guid %s\n", api.JiraIntegration, d.Id())
 	return nil
 }

--- a/lacework/resource_lacework_alert_channel_microsoft_teams.go
+++ b/lacework/resource_lacework_alert_channel_microsoft_teams.go
@@ -41,7 +41,7 @@ func resourceLaceworkAlertChannelMicrosoftTeams() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
-				Description: "Whether to test the integration of an alert channel upon creation",
+				Description: "Whether to test the integration of an alert channel upon creation and modification",
 			},
 			"created_or_updated_time": {
 				Type:     schema.TypeString,
@@ -71,7 +71,6 @@ func resourceLaceworkAlertChannelMicrosoftTeamsCreate(d *schema.ResourceData, me
 				WebhookURL: d.Get("webhook_url").(string),
 			},
 		)
-		testIntegration = d.Get("test_integration").(bool)
 	)
 	if !d.Get("enabled").(bool) {
 		microsoftTeams.Enabled = 0
@@ -99,23 +98,22 @@ func resourceLaceworkAlertChannelMicrosoftTeamsCreate(d *schema.ResourceData, me
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
 
-	if testIntegration {
-		log.Printf("[INFO] Testing %s integration for guid:%s\n", api.DatadogChannelIntegration, d.Id())
-		err := VerifyAlertChannel(d.Id(), lacework)
-		if err != nil {
+	if d.Get("test_integration").(bool) {
+		log.Printf("[INFO] Testing %s integration for guid %s\n", api.MicrosoftTeamsChannelIntegration, d.Id())
+		if err := VerifyAlertChannelAndRollback(d.Id(), lacework); err != nil {
 			return err
 		}
-		log.Printf("[INFO] Tested %s integration with guid: %s successfully \n", api.DatadogChannelIntegration, d.Id())
+		log.Printf("[INFO] Tested %s integration with guid %s successfully\n", api.MicrosoftTeamsChannelIntegration, d.Id())
 	}
 
-	log.Printf("[INFO] Created %s integration with guid: %v\n", api.MicrosoftTeamsChannelIntegration, integration.IntgGuid)
+	log.Printf("[INFO] Created %s integration with guid %s\n", api.MicrosoftTeamsChannelIntegration, integration.IntgGuid)
 	return nil
 }
 
 func resourceLaceworkAlertChannelMicrosoftTeamsRead(d *schema.ResourceData, meta interface{}) error {
 	lacework := meta.(*api.Client)
 
-	log.Printf("[INFO] Reading %s integration with guid: %v\n", api.MicrosoftTeamsChannelIntegration, d.Id())
+	log.Printf("[INFO] Reading %s integration with guid %s\n", api.MicrosoftTeamsChannelIntegration, d.Id())
 	response, err := lacework.Integrations.GetMicrosoftTeamsAlertChannel(d.Id())
 	if err != nil {
 		return err
@@ -132,7 +130,7 @@ func resourceLaceworkAlertChannelMicrosoftTeamsRead(d *schema.ResourceData, meta
 			d.Set("org_level", integration.IsOrg == 1)
 			d.Set("webhook_url", integration.Data.WebhookURL)
 
-			log.Printf("[INFO] Read %s integration with guid: %v\n",
+			log.Printf("[INFO] Read %s integration with guid %s\n",
 				api.MicrosoftTeamsChannelIntegration, integration.IntgGuid)
 			return nil
 		}
@@ -179,20 +177,28 @@ func resourceLaceworkAlertChannelMicrosoftTeamsUpdate(d *schema.ResourceData, me
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
 
-	log.Printf("[INFO] Updated %s integration with guid: %v\n", api.MicrosoftTeamsChannelIntegration, d.Id())
+	if d.Get("test_integration").(bool) {
+		log.Printf("[INFO] Testing %s integration for guid %s\n", api.MicrosoftTeamsChannelIntegration, d.Id())
+		if err := lacework.V2.AlertChannels.Test(d.Id()); err != nil {
+			return err
+		}
+		log.Printf("[INFO] Tested %s integration with guid %s successfully\n", api.MicrosoftTeamsChannelIntegration, d.Id())
+	}
+
+	log.Printf("[INFO] Updated %s integration with guid %s\n", api.MicrosoftTeamsChannelIntegration, d.Id())
 	return nil
 }
 
 func resourceLaceworkAlertChannelMicrosoftTeamsDelete(d *schema.ResourceData, meta interface{}) error {
 	lacework := meta.(*api.Client)
 
-	log.Printf("[INFO] Deleting %s integration with guid: %v\n", api.MicrosoftTeamsChannelIntegration, d.Id())
+	log.Printf("[INFO] Deleting %s integration with guid %s\n", api.MicrosoftTeamsChannelIntegration, d.Id())
 	_, err := lacework.Integrations.Delete(d.Id())
 	if err != nil {
 		return err
 	}
 
-	log.Printf("[INFO] Deleted %s integration with guid: %v\n", api.MicrosoftTeamsChannelIntegration, d.Id())
+	log.Printf("[INFO] Deleted %s integration with guid %s\n", api.MicrosoftTeamsChannelIntegration, d.Id())
 	return nil
 }
 

--- a/lacework/resource_lacework_alert_channel_webhook.go
+++ b/lacework/resource_lacework_alert_channel_webhook.go
@@ -41,7 +41,7 @@ func resourceLaceworkAlertChannelWebhook() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
-				Description: "Whether to test the integration of an alert channel upon creation",
+				Description: "Whether to test the integration of an alert channel upon creation and modification",
 			},
 			"created_or_updated_time": {
 				Type:     schema.TypeString,
@@ -71,7 +71,6 @@ func resourceLaceworkAlertChannelWebhookCreate(d *schema.ResourceData, meta inte
 				WebhookUrl: d.Get("webhook_url").(string),
 			},
 		)
-		testIntegration = d.Get("test_integration").(bool)
 	)
 	if !d.Get("enabled").(bool) {
 		webhook.Enabled = 0
@@ -99,16 +98,15 @@ func resourceLaceworkAlertChannelWebhookCreate(d *schema.ResourceData, meta inte
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
 
-	if testIntegration {
-		log.Printf("[INFO] Testing %s integration for guid:%s\n", api.DatadogChannelIntegration, d.Id())
-		err := VerifyAlertChannel(d.Id(), lacework)
-		if err != nil {
+	if d.Get("test_integration").(bool) {
+		log.Printf("[INFO] Testing %s integration for guid %s\n", api.WebhookIntegration, d.Id())
+		if err := VerifyAlertChannelAndRollback(d.Id(), lacework); err != nil {
 			return err
 		}
-		log.Printf("[INFO] Tested %s integration with guid: %s successfully \n", api.DatadogChannelIntegration, d.Id())
+		log.Printf("[INFO] Tested %s integration with guid %s successfully\n", api.WebhookIntegration, d.Id())
 	}
 
-	log.Printf("[INFO] Created %s integration with guid: %v\n", api.WebhookIntegration, integration.IntgGuid)
+	log.Printf("[INFO] Created %s integration with guid %s\n", api.WebhookIntegration, integration.IntgGuid)
 	return nil
 }
 
@@ -132,7 +130,7 @@ func resourceLaceworkAlertChannelWebhookRead(d *schema.ResourceData, meta interf
 			d.Set("org_level", integration.IsOrg == 1)
 			d.Set("webhook_url", integration.Data.WebhookUrl)
 
-			log.Printf("[INFO] Read %s integration with guid: %v\n",
+			log.Printf("[INFO] Read %s integration with guid %s\n",
 				api.WebhookIntegration, integration.IntgGuid)
 			return nil
 		}
@@ -179,20 +177,28 @@ func resourceLaceworkAlertChannelWebhookUpdate(d *schema.ResourceData, meta inte
 	d.Set("type_name", integration.TypeName)
 	d.Set("org_level", integration.IsOrg == 1)
 
-	log.Printf("[INFO] Updated %s integration with guid: %v\n", api.WebhookIntegration, d.Id())
+	if d.Get("test_integration").(bool) {
+		log.Printf("[INFO] Testing %s integration for guid %s\n", api.WebhookIntegration, d.Id())
+		if err := lacework.V2.AlertChannels.Test(d.Id()); err != nil {
+			return err
+		}
+		log.Printf("[INFO] Tested %s integration with guid %s successfully\n", api.WebhookIntegration, d.Id())
+	}
+
+	log.Printf("[INFO] Updated %s integration with guid %s\n", api.WebhookIntegration, d.Id())
 	return nil
 }
 
 func resourceLaceworkAlertChannelWebhookDelete(d *schema.ResourceData, meta interface{}) error {
 	lacework := meta.(*api.Client)
 
-	log.Printf("[INFO] Deleting %s integration with guid: %v\n", api.WebhookIntegration, d.Id())
+	log.Printf("[INFO] Deleting %s integration with guid %s\n", api.WebhookIntegration, d.Id())
 	_, err := lacework.Integrations.Delete(d.Id())
 	if err != nil {
 		return err
 	}
 
-	log.Printf("[INFO] Deleted %s integration with guid: %v\n", api.WebhookIntegration, d.Id())
+	log.Printf("[INFO] Deleted %s integration with guid %s\n", api.WebhookIntegration, d.Id())
 	return nil
 }
 


### PR DESCRIPTION
PR https://github.com/lacework/terraform-provider-lacework/pull/133 only tested alert channels after creation, but we need to test them
also when users modify them.

Corrected logging that always printed Datadog Integration.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>