### PR TITLE
docs: improve documentation for org account_mappings

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -143,11 +143,11 @@ provider "lacework" {
 !> **Warning:** When accessing organization level data sets, the `subaccount` argument is ignored.
 
 Using this type of configuration is intended for managing resources such as alerts, resource groups, team members,
-cloud accounts, ane more, at the organization level.
+cloud accounts, and more, at the organization level.
 
 ### Migrating existing resources to the Organization level
 
-When trying to migrate and existing resource from one of your Lacework accounts to the organization level,
+When attempting to migrate an existing resource from one of your Lacework accounts to the organization level,
 you need to delete the resource, update the Lacework provider to access the organization level data set, and
 run `terraform apply` to create a new resource at the organization level.
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -142,6 +142,15 @@ provider "lacework" {
 
 !> **Warning:** When accessing organization level data sets, the `subaccount` argument is ignored.
 
+Using this type of configuration is intended for managing resources such as alerts, resource groups, team members,
+cloud accounts, ane more, at the organization level.
+
+### Migrating existing resources to the Organization level
+
+When trying to migrate and existing resource from one of your Lacework accounts to the organization level,
+you need to delete the resource, update the Lacework provider to access the organization level data set, and
+run `terraform apply` to create a new resource at the organization level.
+
 ## Argument Reference
 
 The following arguments are supported in the `provider` block:

--- a/website/docs/r/integration_aws_ct.html.markdown
+++ b/website/docs/r/integration_aws_ct.html.markdown
@@ -24,19 +24,31 @@ resource "lacework_integration_aws_ct" "account_abc" {
 }
 ```
 
-If your Lacework accounts are enrolled in a Lacework organization, you can configure a
-consolidated AWS CloudTrail integration that maps CloudTrail activity from your AWS accounts
-to selected Lacework accounts within your organization.
+## Organization Level Integration
 
-The following snippet adds an AWS CloudTrail integration at the Lacework organization level with
-the following distribution from AWS accounts to Lacework accounts:
+If your Lacework account is enrolled in a Lacework organization, you can configure a
+consolidated AWS CloudTrail integration that maps CloudTrail activity from your AWS
+accounts to selected Lacework accounts within your organization.
+
+To access the organization level data set to manage organization level integrations
+you need to define a Lacework provider with the `organization` argument set to `true`.
+
+The following snippet adds an AWS CloudTrail integration at the organization level of
+your Lacework account with the following distribution from AWS accounts to Lacework
+sub accounts:
 
 * AWS accounts `234556677` and `774564564` will appear in the Lacework account `lw_account_2` 
 * AWS accounts `553453453` and `934534535` will appear in the Lacework account `lw_account_3` 
 * All other AWS accounts that are not mapped will appear in the Lacework account `lw_account_1`
 
 ```hcl
+provider "lacework" {
+  alias = "organization"
+  organization = true
+}
+
 resource "lacework_integration_aws_ct" "consolidated" {
+  alias     = lacework.organization
   name      = "Consolidated CloudTrail"
   queue_url = "https://sqs.us-west-2.amazonaws.com/123456789012/my_queue"
   credentials {
@@ -60,12 +72,65 @@ resource "lacework_integration_aws_ct" "consolidated" {
 }
 ```
 
+!> **Warning:** When accessing organization level data sets, the `subaccount` argument is ignored.
+
 -> **Note:** The mapping that you configure for an organization integration is in addition
 	to what is already configured for the CloudTrail account integration. It doesn't
 	override the existing account integration.
 
 For more information see [Setup of Organization AWS CloudTrail Integration](https://support.lacework.com/hc/en-us/articles/360055993554-Setup-of-Organization-AWS-CloudTrail-Integration)
 
+### Migrating an existing AWS CloudTrail integration to the Organization level
+
+When trying to migrate and existing AWS CloudTrail integration from one of your Lacework accounts
+to the organization level so that you can use the `org_account_mappings` argument, you need to delete
+the integration, update the Lacework provider to access the organization level data set, and run
+`terraform apply` to create a new integration at the organization level.
+
+For example, having this Terraform plan:
+
+```hcl
+provider "lacework" {
+  alias      = "primary"
+  subaccount = "my-company"
+}
+
+resource "lacework_integration_aws_ct" "account_abc" {
+  alias     = lacework.primary
+  name      = "Organization Trail"
+  queue_url = "https://sqs.us-west-2.amazonaws.com/123456789012/my_queue"
+  credentials {
+    role_arn    = "arn:aws:iam::1234567890:role/lacework_iam_example_role"
+    external_id = "12345"
+  }
+}
+```
+
+You could use the [Lacework CLI](https://github.com/lacework/go-sdk/wiki/CLI-Documentation) command `lacework integration delete <INT_GUID>` or, log in to the
+Lacework Console and navigate to Settings > Integrations > Cloud Accounts, to delete the existing
+AWS CloudTrail integration. Then update your Terraform plan to access the organization level data set:
+
+```hcl
+provider "lacework" {
+  alias        = "primary"
+  organization = true
+}
+
+resource "lacework_integration_aws_ct" "account_abc" {
+  alias     = lacework.primary
+  name      = "Organization Trail"
+  queue_url = "https://sqs.us-west-2.amazonaws.com/123456789012/my_queue"
+  credentials {
+    role_arn    = "arn:aws:iam::1234567890:role/lacework_iam_example_role"
+    external_id = "12345"
+  }
+
+  # ... your account mappings goes here ...
+  org_account_mappings {  }
+}
+```
+
+And finally, run `terraform apply` to create a new integration at the organization level.
 
 ## Argument Reference
 

--- a/website/docs/r/integration_aws_ct.html.markdown
+++ b/website/docs/r/integration_aws_ct.html.markdown
@@ -82,7 +82,7 @@ For more information see [Setup of Organization AWS CloudTrail Integration](http
 
 ### Migrating an existing AWS CloudTrail integration to the Organization level
 
-When trying to migrate and existing AWS CloudTrail integration from one of your Lacework accounts
+When attempting to migrate an existing AWS CloudTrail integration from one of your Lacework accounts
 to the organization level so that you can use the `org_account_mappings` argument, you need to delete
 the integration, update the Lacework provider to access the organization level data set, and run
 `terraform apply` to create a new integration at the organization level.


### PR DESCRIPTION
Current documentation for Organization Level integration of Cloud
Accounts is not clear, this change is clarifying the need to define a
new Lacework provider with the argument `organization` set to `true`
to access the organization-level data set.

It also adds a clear example of how to migrate an existing AWS
CloudTrail integration from an account to the organization level.

Closes https://github.com/lacework/terraform-provider-lacework/issues/142

JIRA https://lacework.atlassian.net/browse/ALLY-611

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>