### PR TITLE
feat(resource): New lacework_resource_group_gcp

### DIFF
--- a/examples/resource_lacework_resource_group_gcp/main.tf
+++ b/examples/resource_lacework_resource_group_gcp/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+provider "lacework" {}
+
+resource "lacework_resource_group_gcp" "example" {
+  name         = var.resource_group_name
+  description  = var.description
+  organization = var.organization
+  projects     = var.projects
+}

--- a/examples/resource_lacework_resource_group_gcp/variables.tf
+++ b/examples/resource_lacework_resource_group_gcp/variables.tf
@@ -9,7 +9,7 @@ variable "description" {
 
 variable "organization" {
   type = string
-  default = "Terraform Test All Gcp Projects"
+  default = "MyGcpOrg"
 }
 
 variable "projects" {

--- a/examples/resource_lacework_resource_group_gcp/variables.tf
+++ b/examples/resource_lacework_resource_group_gcp/variables.tf
@@ -4,12 +4,12 @@ variable "resource_group_name" {
 }
 variable "description" {
   type = string
-  default = "Terraform Test All Gcp Accounts"
+  default = "Terraform Test All Gcp Projects"
 }
 
 variable "organization" {
   type = string
-  default = "Terraform Test All Gcp Accounts"
+  default = "Terraform Test All Gcp Projects"
 }
 
 variable "projects" {

--- a/examples/resource_lacework_resource_group_gcp/variables.tf
+++ b/examples/resource_lacework_resource_group_gcp/variables.tf
@@ -1,0 +1,18 @@
+variable "resource_group_name" {
+  type = string
+  default = "Terraform Test Gcp Resource Group"
+}
+variable "description" {
+  type = string
+  default = "Terraform Test All Gcp Accounts"
+}
+
+variable "organization" {
+  type = string
+  default = "Terraform Test All Gcp Accounts"
+}
+
+variable "projects" {
+  type = list(string)
+  default = ["*"]
+}

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -50,3 +50,15 @@ func GetResourceGroupDescription(result string) string {
 
 	return response.Data.Props.Description
 }
+
+func GetGcpResourceGroupProps(result string) api.GcpResourceGroupProps {
+	resultSplit := strings.Split(result, "[id=")
+	id := strings.Split(resultSplit[1], "]")[0]
+
+	response, err := LwClient.V2.ResourceGroups.GetGcp(id)
+	if err != nil {
+		log.Fatalf("Unable to find resource group id: %s\n Response: %v", id, response)
+	}
+
+	return response.Data.Props
+}

--- a/integration/resource_lacework_resource_group_gcp_test.go
+++ b/integration/resource_lacework_resource_group_gcp_test.go
@@ -1,0 +1,33 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestResourceGroupGcpCreate applies integration terraform:
+// => '../examples/resource_lacework_resource_group_gcp'
+//
+// It uses the go-sdk to verify the created resource group,
+// applies an update with new description and destroys it
+func TestResourceGroupGcpCreate(t *testing.T) {
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/resource_lacework_resource_group_gcp",
+		Vars: map[string]interface{}{
+			"description": "Terraform Test Gcp Resource Group",
+		},
+	})
+	defer terraform.Destroy(t, terraformOptions)
+
+	// Create new Gcp Resource Group
+	create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+	assert.Equal(t, "Terraform Test Gcp Resource Group", GetResourceGroupDescription(create))
+
+	// Update Gcp Resource Group
+	terraformOptions.Vars["description"] = "Updated Terraform Test Gcp Resource Group"
+
+	update := terraform.ApplyAndIdempotent(t, terraformOptions)
+	assert.Equal(t, "Updated Terraform Test Gcp Resource Group", GetResourceGroupDescription(update))
+}

--- a/integration/resource_lacework_resource_group_gcp_test.go
+++ b/integration/resource_lacework_resource_group_gcp_test.go
@@ -16,18 +16,28 @@ func TestResourceGroupGcpCreate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_resource_group_gcp",
 		Vars: map[string]interface{}{
-			"description": "Terraform Test Gcp Resource Group",
+			"description":  "Terraform Test Gcp Resource Group",
+			"organization": "MyGcpOrg",
+			"projects":     []string{"pro-123", "pro-321"},
 		},
 	})
 	defer terraform.Destroy(t, terraformOptions)
 
 	// Create new Gcp Resource Group
 	create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
-	assert.Equal(t, "Terraform Test Gcp Resource Group", GetResourceGroupDescription(create))
+	createProps := GetGcpResourceGroupProps(create)
+	assert.Equal(t, "Terraform Test Gcp Resource Group", createProps.Description)
+	assert.Equal(t, "MyGcpOrg", createProps.Organization)
+	assert.Equal(t, []string{"pro-123", "pro-321"}, createProps.Projects)
 
 	// Update Gcp Resource Group
 	terraformOptions.Vars["description"] = "Updated Terraform Test Gcp Resource Group"
+	terraformOptions.Vars["organization"] = "MyGcpOrgUpdated"
+	terraformOptions.Vars["projects"] = []string{"pro-123-updated", "pro-321-updated"}
 
 	update := terraform.ApplyAndIdempotent(t, terraformOptions)
-	assert.Equal(t, "Updated Terraform Test Gcp Resource Group", GetResourceGroupDescription(update))
+	updateProps := GetGcpResourceGroupProps(update)
+	assert.Equal(t, "Updated Terraform Test Gcp Resource Group", updateProps.Description)
+	assert.Equal(t, "MyGcpOrgUpdated", updateProps.Organization)
+	assert.Equal(t, []string{"pro-123-updated", "pro-321-updated"}, updateProps.Projects)
 }

--- a/lacework/provider.go
+++ b/lacework/provider.go
@@ -91,6 +91,7 @@ func Provider() *schema.Provider {
 			"lacework_integration_gcr":               resourceLaceworkIntegrationGcr(),
 			"lacework_integration_ghcr":              resourceLaceworkIntegrationGhcr(),
 			"lacework_resource_group_aws":            resourceLaceworkResourceGroupAws(),
+			"lacework_resource_group_gcp":            resourceLaceworkResourceGroupGcp(),
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/lacework/resource_lacework_resource_group_gcp.go
+++ b/lacework/resource_lacework_resource_group_gcp.go
@@ -39,7 +39,7 @@ func resourceLaceworkResourceGroupGcp() *schema.Resource {
 			"organization": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The GCP organization",
+				Description: "The GCP organization id",
 			},
 			"projects": {
 				Type: schema.TypeList,
@@ -50,7 +50,7 @@ func resourceLaceworkResourceGroupGcp() *schema.Resource {
 					},
 				},
 				Required:    true,
-				Description: "The list of GCP projects to include in the resource group",
+				Description: "The list of GCP project id's to include in the resource group",
 			},
 			"id": {
 				Type:        schema.TypeString,

--- a/lacework/resource_lacework_resource_group_gcp.go
+++ b/lacework/resource_lacework_resource_group_gcp.go
@@ -1,0 +1,200 @@
+package lacework
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"log"
+	"strings"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+func resourceLaceworkResourceGroupGcp() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLaceworkResourceGroupGcpCreate,
+		Read:   resourceLaceworkResourceGroupGcpRead,
+		Update: resourceLaceworkResourceGroupGcpUpdate,
+		Delete: resourceLaceworkResourceGroupGcpDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: importLaceworkResourceGroup,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The resource group name",
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "The state of the resource group",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The description of the resource group",
+			},
+			"organization": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The GCP organization",
+			},
+			"projects": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					StateFunc: func(val interface{}) string {
+						return strings.TrimSpace(val.(string))
+					},
+				},
+				Required:    true,
+				Description: "The list of GCP projects to include in the resource group",
+			},
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The resource group unique identifier",
+			},
+			"lacework_account_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The lacework account id",
+			},
+			"last_updated": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The time in millis when the resource was last updated",
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The username of the lacework user who performed the last update",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of the resource group",
+			},
+			"is_default": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the resource group is a default resource group.",
+			},
+		},
+	}
+}
+
+func resourceLaceworkResourceGroupGcpCreate(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	data := api.NewResourceGroup(d.Get("name").(string),
+		api.GcpResourceGroup,
+		api.GcpResourceGroupProps{
+			Description:  d.Get("description").(string),
+			Organization: d.Get("organization").(string),
+			Projects:     castAttributeToStringSlice(d, "projects"),
+		})
+
+	if !d.Get("enabled").(bool) {
+		data.Enabled = 0
+	}
+
+	log.Printf("[INFO] Creating %s Resource Group with data:\n%+v\n",
+		api.GcpResourceGroup.String(), data)
+	response, err := lacework.V2.ResourceGroups.CreateGcp(&data)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(response.Data.ResourceGuid)
+	d.Set("name", response.Data.Name)
+	d.Set("lacework_account_id", response.Data.Guid)
+	d.Set("enabled", response.Data.Enabled == 1)
+	d.Set("description", response.Data.Props.Description)
+	d.Set("last_updated", response.Data.Props.LastUpdated)
+	d.Set("updated_by", response.Data.Props.UpdatedBy)
+	d.Set("type", response.Data.Type)
+
+	log.Printf("[INFO] Created %s Resource Group with guid %s\n",
+		api.GcpResourceGroup.String(), response.Data.ResourceGuid)
+	return nil
+}
+
+func resourceLaceworkResourceGroupGcpRead(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	log.Printf("[INFO] Reading %s Resource Group with guid %s\n",
+		api.GcpResourceGroup.String(), d.Id())
+	response, err := lacework.V2.ResourceGroups.GetGcp(d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.SetId(response.Data.ResourceGuid)
+	d.Set("name", response.Data.Name)
+	d.Set("lacework_account_id", response.Data.Guid)
+	d.Set("enabled", response.Data.Enabled == 1)
+	d.Set("description", response.Data.Props.Description)
+	d.Set("last_updated", response.Data.Props.LastUpdated)
+	d.Set("updated_by", response.Data.Props.UpdatedBy)
+	d.Set("type", response.Data.Type)
+	d.Set("projects", response.Data.Props.Projects)
+	d.Set("organization", response.Data.Props.Organization)
+
+	log.Printf("[INFO] Read %s Resource Group with guid %s\n",
+		api.GcpResourceGroup.String(), response.Data.ResourceGuid)
+	return nil
+}
+
+func resourceLaceworkResourceGroupGcpUpdate(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	data := api.NewResourceGroup(d.Get("name").(string),
+		api.GcpResourceGroup,
+		api.GcpResourceGroupProps{
+			Description:  d.Get("description").(string),
+			Organization: d.Get("organization").(string),
+			Projects:     castAttributeToStringSlice(d, "projects"),
+		})
+
+	if !d.Get("enabled").(bool) {
+		data.Enabled = 0
+	}
+
+	data.ResourceGuid = d.Id()
+
+	log.Printf("[INFO] Updating %s Resource Group with data:\n%+v\n",
+		api.GcpResourceGroup.String(), data)
+	response, err := lacework.V2.ResourceGroups.UpdateGcp(&data)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(response.Data.ResourceGuid)
+	d.Set("name", response.Data.Name)
+	d.Set("enabled", response.Data.Enabled == 1)
+	d.Set("last_updated", response.Data.Props.LastUpdated)
+	d.Set("updated_by", response.Data.Props.UpdatedBy)
+	d.Set("type", response.Data.Type)
+
+	log.Printf("[INFO] Updated %s Resource Group with guid %s\n",
+		api.GcpResourceGroup.String(), response.Data.ResourceGuid)
+	return nil
+}
+
+func resourceLaceworkResourceGroupGcpDelete(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	log.Printf("[INFO] Deleting %s Resource Group with guid %s\n",
+		api.GcpResourceGroup.String(), d.Id())
+	err := lacework.V2.ResourceGroups.Delete(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Deleted %s Resource Group with guid %s\n",
+		api.GcpResourceGroup.String(), d.Id())
+	return nil
+}

--- a/lacework/resource_lacework_resource_group_gcp.go
+++ b/lacework/resource_lacework_resource_group_gcp.go
@@ -38,7 +38,7 @@ func resourceLaceworkResourceGroupGcp() *schema.Resource {
 			},
 			"organization": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 				Description: "The GCP organization",
 			},
 			"projects": {

--- a/website/docs/r/resource_group_gcp.html.markdown
+++ b/website/docs/r/resource_group_gcp.html.markdown
@@ -8,7 +8,7 @@ Create and manage GCP Resource Groups
 
 # lacework\_resource\_group\_gcp
 
-Use this resource to create an GCP Resource Group in order to categorize Lacework-identifiable assets.
+Use this resource to create a GCP Resource Group in order to categorize Lacework-identifiable assets.
 For more information, see the [Resource Groups documentation](https://support.lacework.com/hc/en-us/articles/360041727354-Resource-Groups).
 
 ## Example Usage
@@ -17,8 +17,8 @@ For more information, see the [Resource Groups documentation](https://support.la
 resource "lacework_resource_group_gcp" "example" {
   name         = "My GCP Resource Group"
   description  = "This groups a subset of Gcp Projects"
-  projects     = ["123456789", "234567891"]
-  organization = "MyGcpOrg"
+  projects     = ["project-1", "project-2", "project-3"]
+  organization = "MyGcpOrgID"
 }
 ```
 
@@ -27,8 +27,8 @@ resource "lacework_resource_group_gcp" "example" {
 The following arguments are supported:
 
 * `name` - (Required) The resource group name.
-* `accounts` - (Required) The list of GCP projects to include in the resource group.
-* `organization` - (Required) The GCP organization.
+* `projects` - (Required) The list of GCP project IDs to include in the resource group.
+* `organization` - (Required) The GCP organization ID.
 * `description` - (Optional) The description of the resource group.
 * `enabled` - (Optional) The state of the external integration. Defaults to `true`.
 

--- a/website/docs/r/resource_group_gcp.html.markdown
+++ b/website/docs/r/resource_group_gcp.html.markdown
@@ -1,0 +1,43 @@
+---
+subcategory: "Resource Groups"
+layout: "lacework"
+page_title: "Lacework: lacework_resource_group_gcp"
+description: |-
+Create and manage GCP Resource Groups
+---
+
+# lacework\_resource\_group\_gcp
+
+Use this resource to create an GCP Resource Group in order to categorize Lacework-identifiable assets.
+For more information, see the [Resource Groups documentation](https://support.lacework.com/hc/en-us/articles/360041727354-Resource-Groups).
+
+## Example Usage
+
+```hcl
+resource "lacework_resource_group_gcp" "example" {
+  name        = "My GCP Resource Group"
+  description = "This groups a subset of Gcp Projects"
+  accounts    = ["123456789", "234567891"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The resource group name.
+* `accounts` - (Required) The list of GCP projects to include in the resource group.
+* `organization` - (Required) The GCP organization.
+* `description` - (Optional) The description of the resource group.
+* `enabled` - (Optional) The state of the external integration. Defaults to `true`.
+
+## Import
+
+A Lacework GCP Resource Group can be imported using a `RESOURCE_GUID`, e.g.
+
+```
+$ terraform import lacework_resource_group_gcp.example EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
+```
+-> **Note:** To retreive the `RESOURCE_GUID` from existing resource groups in your account, use the
+Lacework CLI command `lacework resource-group list`. To install this tool follow
+[this documentation](https://github.com/lacework/go-sdk/wiki/CLI-Documentation#installation).

--- a/website/docs/r/resource_group_gcp.html.markdown
+++ b/website/docs/r/resource_group_gcp.html.markdown
@@ -15,9 +15,10 @@ For more information, see the [Resource Groups documentation](https://support.la
 
 ```hcl
 resource "lacework_resource_group_gcp" "example" {
-  name        = "My GCP Resource Group"
-  description = "This groups a subset of Gcp Projects"
-  accounts    = ["123456789", "234567891"]
+  name         = "My GCP Resource Group"
+  description  = "This groups a subset of Gcp Projects"
+  projects     = ["123456789", "234567891"]
+  organization = "MyGcpOrg"
 }
 ```
 

--- a/website/lacework.erb
+++ b/website/lacework.erb
@@ -174,6 +174,9 @@
                 <li>
                   <a href="/docs/providers/lacework/r/resource_group_aws.html">lacework_resource_group_aws</a>
                 </li>
+                <li>
+                  <a href="/docs/providers/lacework/r/resource_group_gcp.html">lacework_resource_group_gcp</a>
+                </li>
               </ul>
             </li>
           </ul>


### PR DESCRIPTION
Issue: https://lacework.atlassian.net/browse/ALLY-623

New Terraform resource for managing Gcp Resource Groups in Lacework

Usage:

``` hcl
resource "lacework_resource_group_gcp" "gcp" {
  name        = "My Gcp Resource Group"
  description = "This groups a subset of Gcp Accounts"
  organization = "MyGcpOrg"
  projects    = ["123456789", "234567891"]
}
```
Signed-off-by: Darren Murray darren.murray@lacework.net