### PR TITLE
feat(resource): New lacework_resource_group_azure

### DIFF
--- a/examples/resource_lacework_resource_group_azure/main.tf
+++ b/examples/resource_lacework_resource_group_azure/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+provider "lacework" {}
+
+resource "lacework_resource_group_azure" "example" {
+  name          = var.resource_group_name
+  description   = var.description
+  tenant        = var.tenant
+  subscriptions = var.subscriptions
+}

--- a/examples/resource_lacework_resource_group_azure/variables.tf
+++ b/examples/resource_lacework_resource_group_azure/variables.tf
@@ -1,0 +1,18 @@
+variable "resource_group_name" {
+  type = string
+  default = "Terraform Test Azure Resource Group"
+}
+variable "description" {
+  type = string
+  default = "Terraform Test All Azure Accounts"
+}
+
+variable "tenant" {
+  type = string
+  default = "a11aa1ab-111a-11ab-a000-11aa1111a11a"
+}
+
+variable "subscriptions" {
+  type = list(string)
+  default = ["1a1a0b2-abc0-1ab1-1abc-1a000ab0a0a0", "2b000c3-ab10-1a01-1abc-1a000ab0a0a0"]
+}

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -50,3 +50,15 @@ func GetResourceGroupDescription(result string) string {
 
 	return response.Data.Props.Description
 }
+
+func GetAzureResourceGroupProps(result string) api.AzureResourceGroupProps {
+	resultSplit := strings.Split(result, "[id=")
+	id := strings.Split(resultSplit[1], "]")[0]
+
+	response, err := LwClient.V2.ResourceGroups.GetAzure(id)
+	if err != nil {
+		log.Fatalf("Unable to find resource group id: %s\n Response: %v", id, response)
+	}
+
+	return response.Data.Props
+}

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -74,5 +74,3 @@ func GetGcpResourceGroupProps(result string) api.GcpResourceGroupProps {
 
 	return response.Data.Props
 }
-
-

--- a/integration/resource_lacework_resource_group_azure_test.go
+++ b/integration/resource_lacework_resource_group_azure_test.go
@@ -1,0 +1,43 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestResourceGroupAzureCreate applies integration terraform:
+// => '../examples/resource_lacework_resource_group_azure'
+//
+// It uses the go-sdk to verify the created resource group,
+// applies an update with new description and destroys it
+func TestResourceGroupAzureCreate(t *testing.T) {
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/resource_lacework_resource_group_azure",
+		Vars: map[string]interface{}{
+			"description":   "Terraform Test Azure Resource Group",
+			"tenant":   "b21aa1ab-111a-11ab-a000-11aa1111a11a",
+			"subscriptions": []string{"1a1a0b2-abc0-1ab1-1abc-1a000ab0a0a0"},
+		},
+	})
+	defer terraform.Destroy(t, terraformOptions)
+
+	// Create new Azure Resource Group
+	create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+	createProps := GetAzureResourceGroupProps(create)
+	assert.Equal(t, "Terraform Test Azure Resource Group", createProps.Description)
+	assert.Equal(t, "b21aa1ab-111a-11ab-a000-11aa1111a11a", createProps.Tenant)
+	assert.Equal(t, []string{"1a1a0b2-abc0-1ab1-1abc-1a000ab0a0a0"}, createProps.Subscriptions)
+
+	// Update Azure Resource Group
+	terraformOptions.Vars["description"] = "Updated Terraform Test Azure Resource Group"
+	terraformOptions.Vars["tenant"] = "b21aa1ab-111a-11ab-a000-11aa1111a11a"
+	terraformOptions.Vars["subscriptions"] = []string{"231a0b2-abc0-1ab1-1abc-1a000ab0a0a0"}
+
+	update := terraform.ApplyAndIdempotent(t, terraformOptions)
+	updateProps := GetAzureResourceGroupProps(create)
+	assert.Equal(t, "Updated Terraform Test Azure Resource Group", GetResourceGroupDescription(update))
+	assert.Equal(t, "b21aa1ab-111a-11ab-a000-11aa1111a11a", updateProps.Tenant)
+	assert.Equal(t, []string{"231a0b2-abc0-1ab1-1abc-1a000ab0a0a0"}, updateProps.Subscriptions)
+}

--- a/integration/resource_lacework_resource_group_azure_test.go
+++ b/integration/resource_lacework_resource_group_azure_test.go
@@ -17,7 +17,7 @@ func TestResourceGroupAzureCreate(t *testing.T) {
 		TerraformDir: "../examples/resource_lacework_resource_group_azure",
 		Vars: map[string]interface{}{
 			"description":   "Terraform Test Azure Resource Group",
-			"tenant":   "b21aa1ab-111a-11ab-a000-11aa1111a11a",
+			"tenant":        "b21aa1ab-111a-11ab-a000-11aa1111a11a",
 			"subscriptions": []string{"1a1a0b2-abc0-1ab1-1abc-1a000ab0a0a0"},
 		},
 	})

--- a/lacework/provider.go
+++ b/lacework/provider.go
@@ -91,6 +91,7 @@ func Provider() *schema.Provider {
 			"lacework_integration_gcr":               resourceLaceworkIntegrationGcr(),
 			"lacework_integration_ghcr":              resourceLaceworkIntegrationGhcr(),
 			"lacework_resource_group_aws":            resourceLaceworkResourceGroupAws(),
+			"lacework_resource_group_azure":          resourceLaceworkResourceGroupAzure(),
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/lacework/resource_lacework_resource_group_azure.go
+++ b/lacework/resource_lacework_resource_group_azure.go
@@ -39,7 +39,7 @@ func resourceLaceworkResourceGroupAzure() *schema.Resource {
 			"tenant": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The tenant of the resource group",
+				Description: "The Azure tenant id",
 			},
 			"subscriptions": {
 				Type: schema.TypeList,
@@ -50,7 +50,7 @@ func resourceLaceworkResourceGroupAzure() *schema.Resource {
 					},
 				},
 				Required:    true,
-				Description: "The list of Azure subscriptions to include in the resource group",
+				Description: "The list of Azure subscription id's to include in the resource group",
 			},
 			"id": {
 				Type:        schema.TypeString,

--- a/lacework/resource_lacework_resource_group_azure.go
+++ b/lacework/resource_lacework_resource_group_azure.go
@@ -1,0 +1,200 @@
+package lacework
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"log"
+	"strings"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+func resourceLaceworkResourceGroupAzure() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLaceworkResourceGroupAzureCreate,
+		Read:   resourceLaceworkResourceGroupAzureRead,
+		Update: resourceLaceworkResourceGroupAzureUpdate,
+		Delete: resourceLaceworkResourceGroupAzureDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: importLaceworkResourceGroup,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The resource group name",
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "The state of the resource group",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The description of the resource group",
+			},
+			"tenant": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The tenant of the resource group",
+			},
+			"subscriptions": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					StateFunc: func(val interface{}) string {
+						return strings.TrimSpace(val.(string))
+					},
+				},
+				Required:    true,
+				Description: "The list of Azure subscriptions to include in the resource group",
+			},
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The resource group unique identifier",
+			},
+			"lacework_account_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The lacework account id",
+			},
+			"last_updated": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The time in millis when the resource was last updated",
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The username of the lacework user who performed the last update",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of the resource group",
+			},
+			"is_default": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the resource group is a default resource group.",
+			},
+		},
+	}
+}
+
+func resourceLaceworkResourceGroupAzureCreate(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	data := api.NewResourceGroup(d.Get("name").(string),
+		api.AzureResourceGroup,
+		api.AzureResourceGroupProps{
+			Description:   d.Get("description").(string),
+			Tenant:        d.Get("tenant").(string),
+			Subscriptions: castAttributeToStringSlice(d, "subscriptions"),
+		})
+
+	if !d.Get("enabled").(bool) {
+		data.Enabled = 0
+	}
+
+	log.Printf("[INFO] Creating %s Resource Group with data:\n%+v\n",
+		api.AzureResourceGroup.String(), data)
+	response, err := lacework.V2.ResourceGroups.CreateAzure(&data)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(response.Data.ResourceGuid)
+	d.Set("name", response.Data.Name)
+	d.Set("lacework_account_id", response.Data.Guid)
+	d.Set("enabled", response.Data.Enabled == 1)
+	d.Set("description", response.Data.Props.Description)
+	d.Set("last_updated", response.Data.Props.LastUpdated)
+	d.Set("updated_by", response.Data.Props.UpdatedBy)
+	d.Set("type", response.Data.Type)
+
+	log.Printf("[INFO] Created %s Resource Group with guid %s\n",
+		api.AzureResourceGroup.String(), response.Data.ResourceGuid)
+	return nil
+}
+
+func resourceLaceworkResourceGroupAzureRead(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	log.Printf("[INFO] Reading %s Resource Group with guid %s\n",
+		api.AzureResourceGroup.String(), d.Id())
+	response, err := lacework.V2.ResourceGroups.GetAzure(d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.SetId(response.Data.ResourceGuid)
+	d.Set("name", response.Data.Name)
+	d.Set("lacework_account_id", response.Data.Guid)
+	d.Set("enabled", response.Data.Enabled == 1)
+	d.Set("description", response.Data.Props.Description)
+	d.Set("last_updated", response.Data.Props.LastUpdated)
+	d.Set("updated_by", response.Data.Props.UpdatedBy)
+	d.Set("type", response.Data.Type)
+	d.Set("tenant", response.Data.Props.Tenant)
+	d.Set("subscriptions", response.Data.Props.Subscriptions)
+
+	log.Printf("[INFO] Read %s Resource Group with guid %s\n",
+		api.AzureResourceGroup.String(), response.Data.ResourceGuid)
+	return nil
+}
+
+func resourceLaceworkResourceGroupAzureUpdate(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	data := api.NewResourceGroup(d.Get("name").(string),
+		api.AzureResourceGroup,
+		api.AzureResourceGroupProps{
+			Description:   d.Get("description").(string),
+			Tenant:        d.Get("tenant").(string),
+			Subscriptions: castAttributeToStringSlice(d, "subscriptions"),
+		})
+
+	if !d.Get("enabled").(bool) {
+		data.Enabled = 0
+	}
+
+	data.ResourceGuid = d.Id()
+
+	log.Printf("[INFO] Updating %s Resource Group with data:\n%+v\n",
+		api.AzureResourceGroup.String(), data)
+	response, err := lacework.V2.ResourceGroups.UpdateAzure(&data)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(response.Data.ResourceGuid)
+	d.Set("name", response.Data.Name)
+	d.Set("enabled", response.Data.Enabled == 1)
+	d.Set("last_updated", response.Data.Props.LastUpdated)
+	d.Set("updated_by", response.Data.Props.UpdatedBy)
+	d.Set("type", response.Data.Type)
+
+	log.Printf("[INFO] Updated %s Resource Group with guid %s\n",
+		api.AzureResourceGroup.String(), response.Data.ResourceGuid)
+	return nil
+}
+
+func resourceLaceworkResourceGroupAzureDelete(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	log.Printf("[INFO] Deleting %s Resource Group with guid %s\n",
+		api.AzureResourceGroup.String(), d.Id())
+	err := lacework.V2.ResourceGroups.Delete(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Deleted %s Resource Group with guid %s\n",
+		api.AzureResourceGroup.String(), d.Id())
+	return nil
+}

--- a/website/docs/r/resource_group_azure.html.markdown
+++ b/website/docs/r/resource_group_azure.html.markdown
@@ -1,0 +1,44 @@
+---
+subcategory: "Resource Groups"
+layout: "lacework"
+page_title: "Lacework: lacework_resource_group_azure"
+description: |-
+Create and manage Azure Resource Groups
+---
+
+# lacework\_resource\_group\_azure
+
+Use this resource to create an Azure Resource Group in order to categorize Lacework-identifiable assets.
+For more information, see the [Resource Groups documentation](https://support.lacework.com/hc/en-us/articles/360041727354-Resource-Groups).
+
+## Example Usage
+
+```hcl
+resource "lacework_resource_group_azure" "example" {
+  name          = "My Azure Resource Group"
+  description   = "This groups a subset of Azure Subscriptions"
+  tenant        = "a11aa1ab-111a-11ab-a000-11aa1111a11a"
+  subscriptions = ["1a1a0b2-abc0-1ab1-1abc-1a000ab0a0a0", "2b000c3-ab10-1a01-1abc-1a000ab0a0a0"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The resource group name.
+* `tenant` - (Required) The Azure tenant id.
+* `subscriptions` - (Required) The list of Azure subscription ids to include in the resource group.
+* `description` - (Optional) The description of the resource group.
+* `enabled` - (Optional) The state of the external integration. Defaults to `true`.
+
+## Import
+
+A Lacework Azure Resource Group can be imported using a `RESOURCE_GUID`, e.g.
+
+```
+$ terraform import lacework_resource_group_azure.example EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
+```
+-> **Note:** To retreive the `RESOURCE_GUID` from existing resource groups in your account, use the
+Lacework CLI command `lacework resource-group list`. To install this tool follow
+[this documentation](https://github.com/lacework/go-sdk/wiki/CLI-Documentation#installation).

--- a/website/lacework.erb
+++ b/website/lacework.erb
@@ -175,7 +175,7 @@
                   <a href="/docs/providers/lacework/r/resource_group_aws.html">lacework_resource_group_aws</a>
                 </li>
                 <li>
-                  <a href="/docs/providers/lacework/r/resource_group_aws.html">lacework_resource_group_azure</a>
+                  <a href="/docs/providers/lacework/r/resource_group_azure.html">lacework_resource_group_azure</a>
                 </li>
               </ul>
             </li>

--- a/website/lacework.erb
+++ b/website/lacework.erb
@@ -174,6 +174,9 @@
                 <li>
                   <a href="/docs/providers/lacework/r/resource_group_aws.html">lacework_resource_group_aws</a>
                 </li>
+                <li>
+                  <a href="/docs/providers/lacework/r/resource_group_aws.html">lacework_resource_group_azure</a>
+                </li>
               </ul>
             </li>
           </ul>


### PR DESCRIPTION
Issue: https://lacework.atlassian.net/browse/ALLY-624

New Terraform resource for managing Azure Resource Groups in Lacework

Usage:

``` hcl
resource "lacework_resource_group_azure" "azure" {
  name        = "My Gcp Resource Group"
  description   = "This groups a subset of Azure Subscriptions"
  tenant        = "a11aa1ab-111a-11ab-a000-11aa1111a11a"
  subscriptions = ["1a1a0b2-abc0-1ab1-1abc-1a000ab0a0a0", "2b000c3-ab10-1a01-1abc-1a000ab0a0a0"]
}
```

Signed-off-by: Darren Murray darren.murray@lacework.net