### PR TITLE
fix: enable parsing internal accounts

### DIFF
--- a/lacework/provider.go
+++ b/lacework/provider.go
@@ -140,7 +140,7 @@ func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 				Detail:   err.Error(),
 			})
 		} else {
-			account = d.Account
+			account = d.String()
 		}
 	}
 


### PR DESCRIPTION
The function `String()` will detect if the lacework account is in our Frankfurt datacenter or
even an internal Lacework account.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>