### PR TITLE
docs: Add contributing documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: 'bug:'
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Run cmd '...'
+2. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Please complete the following information):**
+ - OS: [e.g. macOS Big Sur 11.5.2 ]
+ - Version [e.g. v0.15.0]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Please complete the following information):**
  - OS: [e.g. macOS Big Sur 11.5.2 ]
- - Version [e.g. v0.15.0]
+ - Provider Version [e.g. v0.15.0]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: 'feat: '
+labels: 'feat'
+---
+
+# Feature Request
+
+**Describe the Feature Request**
+A clear and concise description of what the feature request is. Please include if your feature request is related to a problem
+
+**Is your feature request related to a problem? Please describe**
+Problems related that made you consider this feature request
+
+**Describe Preferred Solution**
+A clear and concise description of what you want to happen and alternatives
+
+**Additional Context**
+List any other information that is relevant to your issue. Stack traces, related issues, suggestions on how to add, use case, Stack Overflow links, forum links, screenshots, OS if applicable, etc.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+---
+name: Pull request template
+about: 'type(scope): Subject of the pull request '
+---
+
+***Issue***: Include link to the Jira/Github Issue
+
+***Description:***
+Provide a detailed description of the changes made by this pull request.
+
+***Additional Info:***
+Include any other relevant information such as how to use the new fuctionality, screenshots, etc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to the Lacework Terraform-Provider-Lacework
+
+### Table Of Contents
+
+* [Before getting started?](#before-getting-started)
+
+* [How to contribute](#how-to-contribute)
+    * [Reporting Bugs](#reporting-bugs)
+    * [Feature Requests](#feature-requests)
+    * [Pull Requests](#pull-requests)
+
+* [Developer Guidelines](/DEVELOPER_GUIDELINES.md)
+
+
+## Before getting started
+
+Read the [README.md](https://github.com/lacework/terraform-provider-lacework/blob/main/README.md), the [developer guidlines](/DEVELOPER_GUIDELINES.md).
+
+## How to contribute
+There are 3 ways that community members can help contribute to the Lacework Terraform Provider.
+Reporting any issues you may find either in functionality of the provider or documentation. Or if you believe some functionality should exist
+within the Lacework Terraform Provider you can make a feature request. Finally, if you've gone one step further and made the changes to submit for a pull request.
+
+### Reporting Bugs
+
+Ensure the issue you are raising has not already been created under [issues](https://github.com/lacework/terraform-provider-lacework/issues).
+
+If no current issue addresses the problem, open a new [issue](https://github.com/lacework/terraform-provider-lacework/issues/new).
+Include as much relevant information as possible. See the [bug template](https://github.com/lacework/terraform-provider-lacework/blob/main/.github/ISSUE_TEMPLATE/bug_report.md) for help on creating a new issue.
+
+### Feature Requests
+
+If you wish to submit a request to add new functionality or an improvement to the terraform-provider-lacework then use the the [feature request](https://github.com/lacework/terraform-provider-lacework/blob/main/.github/ISSUE_TEMPLATE/feature_request.md) template to 
+open a new [issue](https://github.com/lacework/terraform-provider-lacework/issues/new)
+
+### Pull Requests
+
+When submitting a pull request follow the [commit message standard](#commit-message-standard).
+Reduce the likelihood of pushing breaking changes by running the terraform-provider-lacework unit and integration tests.
+
+Thanks,
+
+Project Maintainers
+

--- a/DEVELOPER_GUIDELINES.md
+++ b/DEVELOPER_GUIDELINES.md
@@ -51,3 +51,6 @@ Put as much context as you think it is needed, don’t be shy and explain your t
 
 ### Footer
 The footer is used to reference issues, pull requests or breaking changes, for example, “Fixes ticket #123”.
+
+## Signed Commits
+Signed commits are required for any contribution to this project. Please see Github's documentation on configuring signed commits, [tell git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

--- a/DEVELOPER_GUIDELINES.md
+++ b/DEVELOPER_GUIDELINES.md
@@ -1,0 +1,53 @@
+## Terraform-Provider-Lacework Developer Guidelines
+
+## Commit message standard
+
+The format is:
+```
+type(scope): subject
+BODY
+FOOTER
+```
+
+Each commit message consists of a header, body, and footer. The header is mandatory, the scope is optional, the type and subject are mandatory.
+When writing a commit message try and limit each line of the commit to a max of 100 hundred characters, so it can be read easily.
+
+### Type
+
+| Type | Description |
+| ----- | ----------- |
+| feat: | A new feature you're adding |
+| fix: |A bug fix|
+| style: | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
+| refactor: | A code change that neither fixes a bug nor adds a feature |
+| test: | Everything related to testing |
+| docs: | Everything related to documentation |
+| chore: | Regular code maintenance |
+| build: | Changes that affect the build |
+| ci: | Changes to our CI configuration files and scripts |
+| perf: | A code change that improves performance |
+| metric: | A change that provides better insights about the adoption of features and code statistics |
+
+### Scope
+The optional scope refers to the section that this commit belongs to, for example, changing a specific component or service, a directive, pipes, etc.
+Think about it as an indicator that will let the developers know at first glance what section of your code you are changing.
+
+A few good examples are:
+
+feat(client):
+docs(cli):
+chore(tests):
+ci(directive):
+
+### Subject
+The subject should contain a short description of the change, and written in present-tense, for example, use “add” and not “added”,  or “change” and not “changed”.
+I like to fill this sentence below to understand what should I put as my description of my change:
+
+If applied, this commit will ________________________________________.
+
+### Body
+The body should contain a longer description of the change, try not to repeat the subject and keep it in the present tense as above.
+Put as much context as you think it is needed, don’t be shy and explain your thought process, limitations, ideas for new features or fixes, etc.
+
+### Footer
+The footer is used to reference issues, pull requests or breaking changes, for example, “Fixes ticket #123”.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -38,7 +38,7 @@ release: build-cross-platform ## *CI ONLY* Prepares a release of the Terraform p
 	scripts/release.sh prepare
 
 .PHONY: deps
-deps: ## Update dependencies provided by UPDATE_DEP argument
+deps: ## Update a single dependency by providing the UPDATE_DEP environment variable
 ifdef UPDATE_DEP
 	@go get -u "$(UPDATE_DEP)"
 endif
@@ -77,7 +77,7 @@ uninstall: ## Removes installed provider package from BINARY_PATH
 	@rm -vf $(DIR)/$(PACKAGENAME)
 
 .PHONY: integration-test
-integration-test: clean-test install ## Runs clean-test, install then runs all integration tests
+integration-test: clean-test install ## Runs clean-test and install, then runs all integration tests
 	go test ./integration -v
 
 .PHONY: test

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,7 +20,7 @@ export GOFLAGS CGO_ENABLED
 .PHONY: help
 help:
 	@echo "-------------------------------------------------------------------"
-	@echo "Lacework go-sdk Makefile helper:"
+	@echo "Lacework terraform-provider-lacework Makefile helper:"
 	@echo ""
 	@grep -Fh "##" $(MAKEFILE_LIST) | grep -v grep | sed -e 's/\\$$//' | sed -E 's/^([^:]*):.*##(.*)/ \1 -\2/'
 	@echo "-------------------------------------------------------------------"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -80,8 +80,8 @@ uninstall: ## Removes installed provider package from BINARY_PATH
 integration-test: clean-test install ## Runs clean-test, install then runs all integration tests
 	go test ./integration -v
 
-.PHONY: test ## Runs fmtcheck then runs all unit tests
-test: fmtcheck
+.PHONY: test
+test: fmtcheck ## Runs fmtcheck then runs all unit tests
 	go test $(TEST) || exit 1
 	echo $(TEST) | \
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4


### PR DESCRIPTION
issue: https://lacework.atlassian.net/browse/ALLY-661

Add contributing documentation

CONTRIBUTING.md
DEVELOPER_GUIDELINES.md
ISSUE_TEMPLATE/bug_report.md
ISSUE_TEMPLATE/feature_request.md
ISSUE_TEMPLATE/pull_request_template.md
Add make help

```
❯ make help
-------------------------------------------------------------------
Lacework terraform-provider-lacework Makefile helper:

 ci - *CI ONLY* Runs tests on CI pipeline
 prepare - Initialize the go environment
 release - *CI ONLY* Prepares a release of the Terraform provider
 deps - Update dependencies provided by UPDATE_DEP argument
 alldeps - Update all dependencies
 go-vendor - Runs go mod tidy, vendor and verify to cleanup, copy and verify dependencies
 build - Runs fmtcheck and go install
 build-cross-platform - Compiles the Terraform-Provider-Lacework for all supported platforms
 install - Updates the terraformrc to point to the BINARY_PATH. Installs the provider to the BINARY_PATH
 uninstall - Removes installed provider package from BINARY_PATH
 integration-test - Runs clean-test, install then runs all integration tests
 test - Runs fmtcheck then runs all unit tests
 lint - Runs go linter
 vet - Runs go vet
 fmt - Runs go formatter
 fmtcheck - Runs formatting check
 errcheck - Runs error checking
 test-compile - Compile tests
 install-tools - Install go indirect dependencies
 write-terraform-rc - Write to terraformrc file to mirror lacework/lacework to BINARY_PATH
 clean-test - Find and remove any .terraform directories or tfstate files
-------------------------------------------------------------------

```