### PR TITLE
Updated GCP Resource Group argument reference

### DIFF
--- a/website/docs/r/resource_group_gcp.html.markdown
+++ b/website/docs/r/resource_group_gcp.html.markdown
@@ -28,7 +28,7 @@ The following arguments are supported:
 
 * `name` - (Required) The resource group name.
 * `projects` - (Required) The list of GCP project ids to include in the resource group.
-* `organization` - (Required) The GCP organization id.
+* `organization` - (Required) The GCP organization id. If your project is not part of an organization or if you are looking to group projects across multiple organizations, enter an asterisk `"*"` as a string input. 
 * `description` - (Optional) The description of the resource group.
 * `enabled` - (Optional) The state of the external integration. Defaults to `true`.
 


### PR DESCRIPTION
Added explicit information for how to create a resource group containing a project that is not part of an organization. This also works in grouping projects across organizations or projects in orgs with projects not in orgs.