### PR TITLE
fix: return empty array when casting limit_by fields

### DIFF
--- a/lacework/casting.go
+++ b/lacework/casting.go
@@ -18,7 +18,7 @@ func castStringSlice(iArray []interface{}) []string {
 
 // turn an interface slice into a string slice and apply a transformation func
 func castAndTransformStringSlice(iArray []interface{}, f func(string) string) []string {
-	var a []string
+	a := make([]string, 0)
 	for _, v := range iArray {
 		if v == nil {
 			continue

--- a/lacework/casting_test.go
+++ b/lacework/casting_test.go
@@ -66,6 +66,21 @@ func TestCastAttributeToStringSlice(t *testing.T) {
 	)
 }
 
+func TestCastAttributeToStringSliceEmpty(t *testing.T) {
+	var (
+		expected     = []string{}
+		d            = resourceLaceworkIntegrationDockerHub()
+		testResource = d.TestResourceData()
+	)
+
+	testResource.Set("limit_by_tags", expected)
+	actual := castAttributeToStringSlice(testResource, "limit_by_tags")
+
+	assert.Equal(t, expected, actual,
+		"%s did not match expected value: %s", actual, expected,
+	)
+}
+
 func TestCastAttributeToStringKeyMapOfStrings(t *testing.T) {
 	var (
 		expected     = map[string]string{"foo": "bar", "key": "value"}


### PR DESCRIPTION
issue: https://lacework.atlassian.net/browse/ALLY-674

The function `castAndTransformStringSlice` was returning nil when an empty array is passed in. 

Signed-off-by: Darren Murray <darren.murray@lacework.net>