### PR TITLE
feat: New Machine Resource Group Terraform Resource

### DIFF
--- a/examples/resource_lacework_resource_group_machine/main.tf
+++ b/examples/resource_lacework_resource_group_machine/main.tf
@@ -12,7 +12,7 @@ resource "lacework_resource_group_machine" "example" {
   name            = var.resource_group_name
   description     = var.description
   machine_tags {
-    key = "*"
-    value = "*"
+    key   = var.machine_key
+    value = var.machine_value
   }
 }

--- a/examples/resource_lacework_resource_group_machine/main.tf
+++ b/examples/resource_lacework_resource_group_machine/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+provider "lacework" {}
+
+resource "lacework_resource_group_machine" "example" {
+  name            = var.resource_group_name
+  description     = var.description
+  machine_tags {
+    key = "*"
+    value = "*"
+  }
+}

--- a/examples/resource_lacework_resource_group_machine/variables.tf
+++ b/examples/resource_lacework_resource_group_machine/variables.tf
@@ -1,0 +1,8 @@
+variable "resource_group_name" {
+  type = string
+  default = "Terraform Test Machine Resource Group"
+}
+variable "description" {
+  type = string
+  default = "Terraform Test All Machine Tags"
+}

--- a/examples/resource_lacework_resource_group_machine/variables.tf
+++ b/examples/resource_lacework_resource_group_machine/variables.tf
@@ -6,3 +6,13 @@ variable "description" {
   type = string
   default = "Terraform Test All Machine Tags"
 }
+
+variable "machine_key" {
+  type = string
+  default = "test-key"
+}
+
+variable "machine_value" {
+  type = string
+  default = "test-value"
+}

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -74,3 +74,15 @@ func GetGcpResourceGroupProps(result string) api.GcpResourceGroupProps {
 
 	return response.Data.Props
 }
+
+func GetMachineResourceGroupProps(result string) api.MachineResourceGroupProps {
+	resultSplit := strings.Split(result, "[id=")
+	id := strings.Split(resultSplit[1], "]")[0]
+
+	response, err := LwClient.V2.ResourceGroups.GetMachine(id)
+	if err != nil {
+		log.Fatalf("Unable to find resource group id: %s\n Response: %v", id, response)
+	}
+
+	return response.Data.Props
+}

--- a/integration/resource_lacework_resource_group_machine_test.go
+++ b/integration/resource_lacework_resource_group_machine_test.go
@@ -1,0 +1,33 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestResourceGroupMachineCreate applies integration terraform:
+// => '../examples/resource_lacework_resource_group_machine'
+//
+// It uses the go-sdk to verify the created resource group,
+// applies an update with new description and destroys it
+func TestResourceGroupMachineCreate(t *testing.T) {
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/resource_lacework_resource_group_machine",
+		Vars: map[string]interface{}{
+			"description": "Terraform Test Machine Resource Group",
+		},
+	})
+	defer terraform.Destroy(t, terraformOptions)
+
+	// Create new Machine Resource Group
+	create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+	assert.Equal(t, "Terraform Test Machine Resource Group", GetResourceGroupDescription(create))
+
+	// Update Machine Resource Group
+	terraformOptions.Vars["description"] = "Updated Terraform Test Machine Resource Group"
+
+	update := terraform.ApplyAndIdempotent(t, terraformOptions)
+	assert.Equal(t, "Updated Terraform Test Machine Resource Group", GetResourceGroupDescription(update))
+}

--- a/integration/resource_lacework_resource_group_machine_test.go
+++ b/integration/resource_lacework_resource_group_machine_test.go
@@ -16,18 +16,25 @@ func TestResourceGroupMachineCreate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_resource_group_machine",
 		Vars: map[string]interface{}{
-			"description": "Terraform Test Machine Resource Group",
+			"description":   "Terraform Test Machine Resource Group",
+			"machine_key":   "test-key",
+			"machine_value": "test-value",
 		},
 	})
 	defer terraform.Destroy(t, terraformOptions)
 
 	// Create new Machine Resource Group
 	create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
-	assert.Equal(t, "Terraform Test Machine Resource Group", GetResourceGroupDescription(create))
+	createProps := GetMachineResourceGroupProps(create)
+	assert.Equal(t, "Terraform Test Machine Resource Group", createProps.Description)
+	assert.Equal(t, []map[string]string{{"test-key": "test-value"}}, createProps.MachineTags)
 
 	// Update Machine Resource Group
 	terraformOptions.Vars["description"] = "Updated Terraform Test Machine Resource Group"
+	terraformOptions.Vars["machine_value"] = "updated-value"
 
 	update := terraform.ApplyAndIdempotent(t, terraformOptions)
-	assert.Equal(t, "Updated Terraform Test Machine Resource Group", GetResourceGroupDescription(update))
+	updateProps := GetMachineResourceGroupProps(update)
+	assert.Equal(t, "Updated Terraform Test Machine Resource Group", updateProps.Description)
+	assert.Equal(t, []map[string]string{{"test-key": "updated-value"}}, updateProps.MachineTags)
 }

--- a/lacework/provider.go
+++ b/lacework/provider.go
@@ -94,6 +94,7 @@ func Provider() *schema.Provider {
 			"lacework_resource_group_aws":            resourceLaceworkResourceGroupAws(),
 			"lacework_resource_group_azure":          resourceLaceworkResourceGroupAzure(),
 			"lacework_resource_group_gcp":            resourceLaceworkResourceGroupGcp(),
+			"lacework_resource_group_machine":        resourceLaceworkResourceGroupMachine(),
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/lacework/resource_lacework_resource_group_machine.go
+++ b/lacework/resource_lacework_resource_group_machine.go
@@ -80,7 +80,7 @@ func resourceLaceworkResourceGroupMachine() *schema.Resource {
 			"is_default": {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Description: "Whether the resource group is a default resource group.",
+				Description: "Whether the resource group is a default resource group",
 			},
 		},
 	}

--- a/lacework/resource_lacework_resource_group_machine.go
+++ b/lacework/resource_lacework_resource_group_machine.go
@@ -57,8 +57,7 @@ func resourceLaceworkResourceGroupMachine() *schema.Resource {
 				Computed:    true,
 				Description: "The resource group unique identifier",
 			},
-			"lacework_a" +
-				"ccount_id": {
+			"lacework_account_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The lacework account id",

--- a/lacework/resource_lacework_resource_group_machine.go
+++ b/lacework/resource_lacework_resource_group_machine.go
@@ -1,0 +1,198 @@
+package lacework
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/lacework/go-sdk/api"
+	"log"
+)
+
+func resourceLaceworkResourceGroupMachine() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLaceworkResourceGroupMachineCreate,
+		Read:   resourceLaceworkResourceGroupMachineRead,
+		Update: resourceLaceworkResourceGroupMachineUpdate,
+		Delete: resourceLaceworkResourceGroupMachineDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: importLaceworkResourceGroup,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The resource group name",
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "The state of the resource group",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The description of the resource group",
+			},
+			"machine_tags": {
+				Type: schema.TypeSet,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+				Required:    true,
+				Description: "The list of machines tags to include in the resource group",
+			},
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The resource group unique identifier",
+			},
+			"lacework_a" +
+				"ccount_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The lacework account id",
+			},
+			"last_updated": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The time in millis when the resource was last updated",
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The username of the lacework user who performed the last update",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of the resource group",
+			},
+			"is_default": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the resource group is a default resource group.",
+			},
+		},
+	}
+}
+
+func resourceLaceworkResourceGroupMachineCreate(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	data := api.NewResourceGroup(d.Get("name").(string),
+		api.MachineResourceGroup,
+		api.MachineResourceGroupProps{
+			Description: d.Get("description").(string),
+			MachineTags: castAttributeToArrayOfKeyValueMap(d, "machine_tags"),
+		})
+
+	if !d.Get("enabled").(bool) {
+		data.Enabled = 0
+	}
+
+	log.Printf("[INFO] Creating %s Resource Group with data:\n%+v\n",
+		api.MachineResourceGroup.String(), data)
+	response, err := lacework.V2.ResourceGroups.CreateMachine(&data)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(response.Data.ResourceGuid)
+	d.Set("name", response.Data.Name)
+	d.Set("lacework_account_id", response.Data.Guid)
+	d.Set("enabled", response.Data.Enabled == 1)
+	d.Set("description", response.Data.Props.Description)
+	d.Set("last_updated", response.Data.Props.LastUpdated)
+	d.Set("updated_by", response.Data.Props.UpdatedBy)
+	d.Set("type", response.Data.Type)
+
+	log.Printf("[INFO] Created %s Resource Group with guid %s\n",
+		api.MachineResourceGroup.String(), response.Data.ResourceGuid)
+	return nil
+}
+
+func resourceLaceworkResourceGroupMachineRead(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	log.Printf("[INFO] Reading %s Resource Group with guid %s\n",
+		api.MachineResourceGroup.String(), d.Id())
+	response, err := lacework.V2.ResourceGroups.GetMachine(d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.SetId(response.Data.ResourceGuid)
+	d.Set("name", response.Data.Name)
+	d.Set("lacework_account_id", response.Data.Guid)
+	d.Set("enabled", response.Data.Enabled == 1)
+	d.Set("description", response.Data.Props.Description)
+	d.Set("last_updated", response.Data.Props.LastUpdated)
+	d.Set("updated_by", response.Data.Props.UpdatedBy)
+	d.Set("type", response.Data.Type)
+	d.Set("machine_tags", response.Data.Props.MachineTags)
+
+	log.Printf("[INFO] Read %s Resource Group with guid %s\n",
+		api.MachineResourceGroup.String(), response.Data.ResourceGuid)
+	return nil
+}
+
+func resourceLaceworkResourceGroupMachineUpdate(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	data := api.NewResourceGroup(d.Get("name").(string),
+		api.MachineResourceGroup,
+		api.MachineResourceGroupProps{
+			Description: d.Get("description").(string),
+			MachineTags: castAttributeToArrayOfKeyValueMap(d, "machine_tags"),
+		})
+
+	if !d.Get("enabled").(bool) {
+		data.Enabled = 0
+	}
+
+	data.ResourceGuid = d.Id()
+
+	log.Printf("[INFO] Updating %s Resource Group with data:\n%+v\n",
+		api.MachineResourceGroup.String(), data)
+	response, err := lacework.V2.ResourceGroups.UpdateMachine(&data)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(response.Data.ResourceGuid)
+	d.Set("name", response.Data.Name)
+	d.Set("enabled", response.Data.Enabled == 1)
+	d.Set("last_updated", response.Data.Props.LastUpdated)
+	d.Set("updated_by", response.Data.Props.UpdatedBy)
+	d.Set("type", response.Data.Type)
+
+	log.Printf("[INFO] Updated %s Resource Group with guid %s\n",
+		api.MachineResourceGroup.String(), response.Data.ResourceGuid)
+	return nil
+}
+
+func resourceLaceworkResourceGroupMachineDelete(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	log.Printf("[INFO] Deleting %s Resource Group with guid %s\n",
+		api.MachineResourceGroup.String(), d.Id())
+	err := lacework.V2.ResourceGroups.Delete(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Deleted %s Resource Group with guid %s\n",
+		api.MachineResourceGroup.String(), d.Id())
+	return nil
+}

--- a/website/docs/r/resource_group_machine.html.markdown
+++ b/website/docs/r/resource_group_machine.html.markdown
@@ -1,0 +1,45 @@
+---
+subcategory: "Resource Groups"
+layout: "lacework"
+page_title: "Lacework: lacework_resource_group_machine"
+description: |-
+  Create and manage Machine Resource Groups
+---
+
+# lacework\_resource\_group\_machine
+
+Use this resource to create a Machine Resource Group in order to categorize Lacework-identifiable assets.
+For more information, see the [Resource Groups documentation](https://support.lacework.com/hc/en-us/articles/360041727354-Resource-Groups).
+
+## Example Usage
+
+```hcl
+resource "lacework_resource_group_machine" "example" {
+  name        = "My Machine Resource Group"
+  description = "This groups a subset of Machine Tags"
+  machine_tags {
+    key = "name"
+    value = "myMachine"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The resource group name.
+* `machine_tags` - (Required) The key value pairs of machine tags to include in the resource group.
+* `description` - (Optional) The description of the resource group.
+* `enabled` - (Optional) The state of the external integration. Defaults to `true`.
+
+## Import
+
+A Lacework Machine Resource Group can be imported using a `RESOURCE_GUID`, e.g.
+
+```
+$ terraform import lacework_resource_group_machine.example EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
+```
+-> **Note:** To retreive the `RESOURCE_GUID` from existing resource groups in your account, use the
+Lacework CLI command `lacework resource-group list`. To install this tool follow
+[this documentation](https://github.com/lacework/go-sdk/wiki/CLI-Documentation#installation).

--- a/website/docs/r/resource_group_machine.html.markdown
+++ b/website/docs/r/resource_group_machine.html.markdown
@@ -18,7 +18,7 @@ resource "lacework_resource_group_machine" "example" {
   name        = "My Machine Resource Group"
   description = "This groups a subset of Machine Tags"
   machine_tags {
-    key = "name"
+    key   = "name"
     value = "myMachine"
   }
 }

--- a/website/lacework.erb
+++ b/website/lacework.erb
@@ -180,6 +180,9 @@
                 <li>
                   <a href="/docs/providers/lacework/r/resource_group_gcp.html">lacework_resource_group_gcp</a>
                 </li>
+                <li>
+                  <a href="/docs/providers/lacework/r/resource_group_machine.html">lacework_resource_group_machine</a>
+                </li>
               </ul>
             </li>
           </ul>


### PR DESCRIPTION
Issue: https://lacework.atlassian.net/browse/ALLY-626

New Terraform resource for managing Machine Resource Groups in Lacework

Usage:

``` hcl
resource "lacework_resource_group_machine" "machine" {
  name        = "My Machine Resource Group"
  description   = "This groups a subset of Machine Tags"
  machine_tags {
    key = "myKey"
    value = "myValue"
    }
}
```

Signed-off-by: Darren Murray darren.murray@lacework.net