### PR TITLE
feat: New Container Resource Group Terraform Resource

### DIFF
--- a/examples/resource_lacework_resource_group_container/main.tf
+++ b/examples/resource_lacework_resource_group_container/main.tf
@@ -11,9 +11,9 @@ provider "lacework" {}
 resource "lacework_resource_group_container" "example" {
   name            = var.resource_group_name
   description     = var.description
-  container_tags  = ["myTag"]
+  container_tags  = var.ctr_tags
   container_labels {
-    key = "*"
-    value = "*"
+    key   = var.ctr_key
+    value = var.ctr_value
   }
 }

--- a/examples/resource_lacework_resource_group_container/main.tf
+++ b/examples/resource_lacework_resource_group_container/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+provider "lacework" {}
+
+resource "lacework_resource_group_container" "example" {
+  name            = var.resource_group_name
+  description     = var.description
+  container_tags  = ["myTag"]
+  container_labels {
+    key = "*"
+    value = "*"
+  }
+}

--- a/examples/resource_lacework_resource_group_container/variables.tf
+++ b/examples/resource_lacework_resource_group_container/variables.tf
@@ -6,3 +6,18 @@ variable "description" {
   type = string
   default = "Terraform Test All Container Tags"
 }
+
+variable "ctr_key" {
+  type = string
+  default = "test-key"
+}
+
+variable "ctr_value" {
+  type = string
+  default = "test-value"
+}
+
+variable "ctr_tags" {
+  type = list(string)
+  default = ["test-tag"]
+}

--- a/examples/resource_lacework_resource_group_container/variables.tf
+++ b/examples/resource_lacework_resource_group_container/variables.tf
@@ -1,0 +1,8 @@
+variable "resource_group_name" {
+  type = string
+  default = "Terraform Test Container Resource Group"
+}
+variable "description" {
+  type = string
+  default = "Terraform Test All Container Tags"
+}

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -74,3 +74,15 @@ func GetGcpResourceGroupProps(result string) api.GcpResourceGroupProps {
 
 	return response.Data.Props
 }
+
+func GetContainerResourceGroupProps(result string) api.ContainerResourceGroupProps {
+	resultSplit := strings.Split(result, "[id=")
+	id := strings.Split(resultSplit[1], "]")[0]
+
+	response, err := LwClient.V2.ResourceGroups.GetContainer(id)
+	if err != nil {
+		log.Fatalf("Unable to find resource group id: %s\n Response: %v", id, response)
+	}
+
+	return response.Data.Props
+}

--- a/integration/resource_lacework_resource_group_container_test.go
+++ b/integration/resource_lacework_resource_group_container_test.go
@@ -17,17 +17,28 @@ func TestResourceGroupContainerCreate(t *testing.T) {
 		TerraformDir: "../examples/resource_lacework_resource_group_container",
 		Vars: map[string]interface{}{
 			"description": "Terraform Test Container Resource Group",
+			"ctr_tags":    []string{"test-tag"},
+			"ctr_key":     "test-key",
+			"ctr_value":   "test-value",
 		},
 	})
 	defer terraform.Destroy(t, terraformOptions)
 
 	// Create new Container Resource Group
 	create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
-	assert.Equal(t, "Terraform Test Container Resource Group", GetResourceGroupDescription(create))
+	createProps := GetContainerResourceGroupProps(create)
+	assert.Equal(t, "Terraform Test Container Resource Group", createProps.Description)
+	assert.Equal(t, []string{"test-tag"}, createProps.ContainerTags)
+	assert.Equal(t, []map[string]string{{"test-key": "test-value"}}, createProps.ContainerLabels)
 
 	// Update Container Resource Group
 	terraformOptions.Vars["description"] = "Updated Terraform Test Container Resource Group"
+	terraformOptions.Vars["ctr_tags"] = []string{"updated-tag"}
+	terraformOptions.Vars["ctr_value"] = "updated-value"
 
 	update := terraform.ApplyAndIdempotent(t, terraformOptions)
-	assert.Equal(t, "Updated Terraform Test Container Resource Group", GetResourceGroupDescription(update))
+	updateProps := GetContainerResourceGroupProps(update)
+	assert.Equal(t, "Updated Terraform Test Container Resource Group", updateProps.Description)
+	assert.Equal(t, []string{"updated-tag"}, updateProps.ContainerTags)
+	assert.Equal(t, []map[string]string{{"test-key": "updated-value"}}, updateProps.ContainerLabels)
 }

--- a/integration/resource_lacework_resource_group_container_test.go
+++ b/integration/resource_lacework_resource_group_container_test.go
@@ -1,0 +1,33 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestResourceGroupContainerCreate applies integration terraform:
+// => '../examples/resource_lacework_resource_group_container'
+//
+// It uses the go-sdk to verify the created resource group,
+// applies an update with new description and destroys it
+func TestResourceGroupContainerCreate(t *testing.T) {
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/resource_lacework_resource_group_container",
+		Vars: map[string]interface{}{
+			"description": "Terraform Test Container Resource Group",
+		},
+	})
+	defer terraform.Destroy(t, terraformOptions)
+
+	// Create new Container Resource Group
+	create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+	assert.Equal(t, "Terraform Test Container Resource Group", GetResourceGroupDescription(create))
+
+	// Update Container Resource Group
+	terraformOptions.Vars["description"] = "Updated Terraform Test Container Resource Group"
+
+	update := terraform.ApplyAndIdempotent(t, terraformOptions)
+	assert.Equal(t, "Updated Terraform Test Container Resource Group", GetResourceGroupDescription(update))
+}

--- a/lacework/provider.go
+++ b/lacework/provider.go
@@ -93,6 +93,7 @@ func Provider() *schema.Provider {
 			"lacework_integration_ghcr":              resourceLaceworkIntegrationGhcr(),
 			"lacework_resource_group_aws":            resourceLaceworkResourceGroupAws(),
 			"lacework_resource_group_azure":          resourceLaceworkResourceGroupAzure(),
+			"lacework_resource_group_container":      resourceLaceworkResourceGroupContainer(),
 			"lacework_resource_group_gcp":            resourceLaceworkResourceGroupGcp(),
 		},
 

--- a/lacework/resource_lacework_resource_group_container.go
+++ b/lacework/resource_lacework_resource_group_container.go
@@ -1,0 +1,212 @@
+package lacework
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/lacework/go-sdk/api"
+	"log"
+	"strings"
+)
+
+func resourceLaceworkResourceGroupContainer() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLaceworkResourceGroupContainerCreate,
+		Read:   resourceLaceworkResourceGroupContainerRead,
+		Update: resourceLaceworkResourceGroupContainerUpdate,
+		Delete: resourceLaceworkResourceGroupContainerDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: importLaceworkResourceGroup,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The resource group name",
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "The state of the resource group",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The description of the resource group",
+			},
+			"container_labels": {
+				Type: schema.TypeSet,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+				Required:    true,
+				Description: "The key value pairs of container labels to include in the resource group",
+			},
+			"container_tags": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					StateFunc: func(val interface{}) string {
+						return strings.TrimSpace(val.(string))
+					},
+				},
+				Required:    true,
+				Description: "The list of containers tags to include in the resource group",
+			},
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The resource group unique identifier",
+			},
+			"lacework_account_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The lacework account id",
+			},
+			"last_updated": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The time in millis when the resource was last updated",
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The username of the lacework user who performed the last update",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of the resource group",
+			},
+			"is_default": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the resource group is a default resource group.",
+			},
+		},
+	}
+}
+
+func resourceLaceworkResourceGroupContainerCreate(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	data := api.NewResourceGroup(d.Get("name").(string),
+		api.ContainerResourceGroup,
+		api.ContainerResourceGroupProps{
+			Description:     d.Get("description").(string),
+			ContainerLabels: castAttributeToArrayOfKeyValueMap(d, "container_labels"),
+			ContainerTags:   castAttributeToStringSlice(d, "container_tags"),
+		})
+
+	if !d.Get("enabled").(bool) {
+		data.Enabled = 0
+	}
+
+	log.Printf("[INFO] Creating %s Resource Group with data:\n%+v\n",
+		api.ContainerResourceGroup.String(), data)
+	response, err := lacework.V2.ResourceGroups.CreateContainer(&data)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(response.Data.ResourceGuid)
+	d.Set("name", response.Data.Name)
+	d.Set("lacework_account_id", response.Data.Guid)
+	d.Set("enabled", response.Data.Enabled == 1)
+	d.Set("description", response.Data.Props.Description)
+	d.Set("last_updated", response.Data.Props.LastUpdated)
+	d.Set("updated_by", response.Data.Props.UpdatedBy)
+	d.Set("type", response.Data.Type)
+
+	log.Printf("[INFO] Created %s Resource Group with guid %s\n",
+		api.ContainerResourceGroup.String(), response.Data.ResourceGuid)
+	return nil
+}
+
+func resourceLaceworkResourceGroupContainerRead(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	log.Printf("[INFO] Reading %s Resource Group with guid %s\n",
+		api.ContainerResourceGroup.String(), d.Id())
+	response, err := lacework.V2.ResourceGroups.GetContainer(d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.SetId(response.Data.ResourceGuid)
+	d.Set("name", response.Data.Name)
+	d.Set("lacework_account_id", response.Data.Guid)
+	d.Set("enabled", response.Data.Enabled == 1)
+	d.Set("description", response.Data.Props.Description)
+	d.Set("last_updated", response.Data.Props.LastUpdated)
+	d.Set("updated_by", response.Data.Props.UpdatedBy)
+	d.Set("type", response.Data.Type)
+	d.Set("container_tags", response.Data.Props.ContainerTags)
+	d.Set("container_labels", response.Data.Props.ContainerLabels)
+
+	log.Printf("[INFO] Read %s Resource Group with guid %s\n",
+		api.ContainerResourceGroup.String(), response.Data.ResourceGuid)
+	return nil
+}
+
+func resourceLaceworkResourceGroupContainerUpdate(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	data := api.NewResourceGroup(d.Get("name").(string),
+		api.ContainerResourceGroup,
+		api.ContainerResourceGroupProps{
+			Description:     d.Get("description").(string),
+			ContainerLabels: castAttributeToArrayOfKeyValueMap(d, "container_labels"),
+			ContainerTags:   castAttributeToStringSlice(d, "container_tags"),
+		})
+
+	if !d.Get("enabled").(bool) {
+		data.Enabled = 0
+	}
+
+	data.ResourceGuid = d.Id()
+
+	log.Printf("[INFO] Updating %s Resource Group with data:\n%+v\n",
+		api.ContainerResourceGroup.String(), data)
+	response, err := lacework.V2.ResourceGroups.UpdateContainer(&data)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(response.Data.ResourceGuid)
+	d.Set("name", response.Data.Name)
+	d.Set("enabled", response.Data.Enabled == 1)
+	d.Set("last_updated", response.Data.Props.LastUpdated)
+	d.Set("updated_by", response.Data.Props.UpdatedBy)
+	d.Set("type", response.Data.Type)
+
+	log.Printf("[INFO] Updated %s Resource Group with guid %s\n",
+		api.ContainerResourceGroup.String(), response.Data.ResourceGuid)
+	return nil
+}
+
+func resourceLaceworkResourceGroupContainerDelete(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	log.Printf("[INFO] Deleting %s Resource Group with guid %s\n",
+		api.ContainerResourceGroup.String(), d.Id())
+	err := lacework.V2.ResourceGroups.Delete(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Deleted %s Resource Group with guid %s\n",
+		api.ContainerResourceGroup.String(), d.Id())
+	return nil
+}

--- a/lacework/resource_lacework_resource_group_container.go
+++ b/lacework/resource_lacework_resource_group_container.go
@@ -92,7 +92,7 @@ func resourceLaceworkResourceGroupContainer() *schema.Resource {
 			"is_default": {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Description: "Whether the resource group is a default resource group.",
+				Description: "Whether the resource group is a default resource group",
 			},
 		},
 	}

--- a/website/docs/r/resource_group_container.html.markdown
+++ b/website/docs/r/resource_group_container.html.markdown
@@ -15,11 +15,11 @@ For more information, see the [Resource Groups documentation](https://support.la
 
 ```hcl
 resource "lacework_resource_group_container" "example" {
-  name        = "My Container Resource Group"
-  description = "This groups a subset of Container Tags"
+  name           = "My Container Resource Group"
+  description    = "This groups a subset of Container Tags"
   container_tags = ["my-container"]
   container_label {
-    key = "name"
+    key   = "name"
     value = "my-container"
   }
 }

--- a/website/docs/r/resource_group_container.html.markdown
+++ b/website/docs/r/resource_group_container.html.markdown
@@ -1,0 +1,47 @@
+---
+subcategory: "Resource Groups"
+layout: "lacework"
+page_title: "Lacework: lacework_resource_group_container"
+description: |-
+  Create and manage Container Resource Groups
+---
+
+# lacework\_resource\_group\_container
+
+Use this resource to create a Container Resource Group in order to categorize Lacework-identifiable assets.
+For more information, see the [Resource Groups documentation](https://support.lacework.com/hc/en-us/articles/360041727354-Resource-Groups).
+
+## Example Usage
+
+```hcl
+resource "lacework_resource_group_container" "example" {
+  name        = "My Container Resource Group"
+  description = "This groups a subset of Container Tags"
+  container_tags = ["my-container"]
+  container_label {
+    key = "name"
+    value = "my-container"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The resource group name.
+* `container_labels` - (Required) The key value pairs of container labels to include in the resource group.
+* `container_tags` - (Required) The list of container tags to include in the resource group.
+* `description` - (Optional) The description of the resource group.
+* `enabled` - (Optional) The state of the external integration. Defaults to `true`.
+
+## Import
+
+A Lacework Container Resource Group can be imported using a `RESOURCE_GUID`, e.g.
+
+```
+$ terraform import lacework_resource_group_container.example EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
+```
+-> **Note:** To retreive the `RESOURCE_GUID` from existing resource groups in your account, use the
+Lacework CLI command `lacework resource-group list`. To install this tool follow
+[this documentation](https://github.com/lacework/go-sdk/wiki/CLI-Documentation#installation).

--- a/website/lacework.erb
+++ b/website/lacework.erb
@@ -180,6 +180,9 @@
                 <li>
                   <a href="/docs/providers/lacework/r/resource_group_gcp.html">lacework_resource_group_gcp</a>
                 </li>
+                <li>
+                  <a href="/docs/providers/lacework/r/resource_group_container.html">lacework_resource_group_container</a>
+                </li>
               </ul>
             </li>
           </ul>


### PR DESCRIPTION
Issue: https://lacework.atlassian.net/browse/ALLY-625

New Terraform resource for managing Container Resource Groups in Lacework

Usage:

``` hcl
resource "lacework_resource_group_container" "container" {
  name        = "My Machine Resource Group"
  description   = "This groups a subset of Machine Tags"
  container_tags = ["myTag"]
  container_labels {
    key = "myKey"
    value = "myValue"
    }
}
```

Signed-off-by: Darren Murray darren.murray@lacework.net