### PR TITLE
docs: update multiple aliases for sub-accounts

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -147,8 +147,9 @@ module "lacework_module" {
 module "lacework_module" {
   source  = "lacework/s3-data-export/aws"
   version = "~> 0.1"
+
   providers = {
-  lacework = lacework.business-unit
+    lacework = lacework.business-unit
   }
  # ...
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -137,8 +137,9 @@ For module blocks you can can reference the `alias` using :
 module "lacework_module" {
   source  = "lacework/s3-data-export/aws"
   version = "~> 0.1"
+
   providers = {
-  lacework = lacework.primary
+    lacework = lacework.primary
   }
   # ...
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -119,7 +119,7 @@ provider "lacework" {
 
 From there, you can pass the [`alias` meta-argument](https://www.terraform.io/docs/language/providers/configuration.html#alias-multiple-provider-configurations) to any resource or module to switch between accounts.
 
-For resource blocks you can can reference the `alias` using : 
+For a resource or data source, set its `provider` meta-argument to a `lacework.<ALIAS>` reference:
 ```hcl
 resource "lacework_alert_channel_slack" "primary_critical" {
   provider = lacework.primary
@@ -132,7 +132,7 @@ resource "lacework_alert_channel_slack" "business_unit_critical" {
 }
 ```
 
-For module blocks you can can reference the `alias` using :
+For a module, use its `providers` meta-argument to specify which provider configurations should be mapped to which local provider names inside the module:
 ```hcl
 module "lacework_module" {
   source  = "lacework/s3-data-export/aws"

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -117,15 +117,39 @@ provider "lacework" {
 }
 ```
 
-From there, you can pass the [`alias` meta-argument](https://www.terraform.io/docs/language/providers/configuration.html#alias-multiple-provider-configurations) to any resource to switch between accounts:
+From there, you can pass the [`alias` meta-argument](https://www.terraform.io/docs/language/providers/configuration.html#alias-multiple-provider-configurations) to any resource or module to switch between accounts.
+
+For resource blocks you can can reference the `alias` using : 
 ```hcl
 resource "lacework_alert_channel_slack" "primary_critical" {
-  alias = lacework.primary
+  provider = lacework.primary
   # ...
 }
+
 resource "lacework_alert_channel_slack" "business_unit_critical" {
-  alias = lacework.business-unit
+  provider = lacework.business-unit
   # ...
+}business-unit
+```
+
+For module blocks you can can reference the `alias` using :
+```hcl
+module "lacework_module" {
+  source  = "lacework/s3-data-export/aws"
+  version = "~> 0.1"
+  providers = {
+  lacework = lacework.primary
+  }
+  # ...
+}
+
+module "lacework_module" {
+  source  = "lacework/s3-data-export/aws"
+  version = "~> 0.1"
+  providers = {
+  lacework = lacework.business-unit
+  }
+ # ...
 }
 ```
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -129,7 +129,7 @@ resource "lacework_alert_channel_slack" "primary_critical" {
 resource "lacework_alert_channel_slack" "business_unit_critical" {
   provider = lacework.business-unit
   # ...
-}business-unit
+}
 ```
 
 For module blocks you can can reference the `alias` using :


### PR DESCRIPTION
Signed-off-by: Robert Wedd <robert.wedd@lacework.net>

---
name: Updated documentation for using multiple aliases for SubAccounts
about: 'type(doc): Subject of the pull request '
---

***Issue***: Include link to the Jira/Github Issue

***Description:***
Documentation was incorrect on how to use aliases for providers with sub accounts

***Additional Info:***
Include any other relevant information such as how to use the new fuctionality, screenshots, etc.