### PR TITLE
fix: increase timeout from 60 to 125 seconds

### DIFF
--- a/lacework/provider.go
+++ b/lacework/provider.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -119,7 +120,10 @@ func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 		key          = d.Get("api_key").(string)
 		secret       = d.Get("api_secret").(string)
 		userAgent    = fmt.Sprintf("Terraform/%s", version)
-		apiOpts      = []api.Option{api.WithHeader("User-Agent", userAgent)}
+		apiOpts      = []api.Option{
+			api.WithHeader("User-Agent", userAgent),
+			api.WithTimeout(time.Second * 125), // this is our nginx max time
+		}
 	)
 
 	// validate that the log level is supported by the api client, if not,


### PR DESCRIPTION
***Issue***: https://lacework.atlassian.net/browse/ALLY-698

***Description:***
We had a default timeout of 1 minute which combined with our retries for
the resource `lacework_integration_aws_ct` made it so that customers
will end up with two integrations, one successful and the other one with
the following failure:
```
Error: Error creating AwsCtSqs cloud account integration: 
  [POST] https://customerdemo.lacework.net/api/v2/CloudAccounts
  [400] Specified AWS SQS resources are already used in this Lacework Application.
```

Doing troubleshooting we noticed that the request timed out and we were
trying to retry. We are fixing this bug by increasing the timeout to the
double temporarily.


```
FIRST POST /api/v2/CloudAccounts

module.aws_cloudtrail.lacework_integration_aws_ct.default[0]: Still creating... [10s elapsed]
module.aws_cloudtrail.lacework_integration_aws_ct.default[0]: Still creating... [20s elapsed]
module.aws_cloudtrail.lacework_integration_aws_ct.default[0]: Still creating... [30s elapsed]
module.aws_cloudtrail.lacework_integration_aws_ct.default[0]: Still creating... [40s elapsed]
module.aws_cloudtrail.lacework_integration_aws_ct.default[0]: Still creating... [50s elapsed]
module.aws_cloudtrail.lacework_integration_aws_ct.default[0]: Still creating... [1m0s elapsed]
2021-10-11T16:23:03.227Z [INFO]  plugin.terraform-provider-lacework_v0.11.0: 2021/10/11 16:23:03 [INFO] Unable to create AwsCtSqs cloud account integration. (retrying 4 more time(s))
Post "https://customerdemo.lacework.net/api/v2/CloudAccounts": context deadline exceeded (Client.Timeout exceeded while awaiting headers): timestamp=2021-10-11T16:23:03.227Z
2021-10-11T16:23:03.227Z [INFO]  plugin.terraform-provider-lacework_v0.11.0: 2021/10/11 16:23:03 [TRACE] Waiting 500ms before next try: timestamp=2021-10-11T16:23:03.227Z
2021-10-11T16:23:03.728Z [INFO]  plugin.terraform-provider-lacework_v0.11.0: 2021/10/11 16:23:03 [INFO] Creating AwsCtSqs cloud account integration: timestamp=2021-10-11T16:23:03.728Z

SECOND POST /api/v2/CloudAccounts
module.aws_cloudtrail.lacework_integration_aws_ct.default[0]: Still creating... [1m10s elapsed]
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>