### PR TITLE
fix: Migrate IbmQRadar alert channel(v2)

### DIFF
--- a/examples/resource_lacework_alert_channel_qradar/main.tf
+++ b/examples/resource_lacework_alert_channel_qradar/main.tf
@@ -1,8 +1,55 @@
-provider "lacework" {}
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
 
 resource "lacework_alert_channel_qradar" "example" {
-  name               = "QRadar Channel Alert Example"
-  host_url           = "https://qradar-lacework.com"
-  host_port          = 4000
-  communication_type = "HTTPS"
+  name               = var.channel_name
+  host_url           = var.host_url
+  host_port          = var.host_port
+  communication_type = var.communication_type
+  // test_integration input is used in this example only for testing
+  // purposes, it help us avoid sending a "test" request to the
+  // system we are integrating to. In production, this should remain
+  // turned on ("true") which is the default setting
+  test_integration = false
+}
+
+variable "channel_name" {
+  type    = string
+  default = "IbmQRadar Alert Channel"
+}
+
+variable "host_url" {
+  type    = string
+  default = "https://qradar-lacework.com"
+}
+
+variable "host_port" {
+  type    = number
+  default = 4000
+}
+
+variable "communication_type" {
+  type    = string
+  default = "HTTPS"
+}
+
+output "channel_name" {
+  value = lacework_alert_channel_qradar.example.name
+}
+
+output "host_url" {
+  value = lacework_alert_channel_qradar.example.host_url
+}
+
+output "host_port" {
+  value = lacework_alert_channel_qradar.example.host_port
+}
+
+output "communication_type" {
+  value = lacework_alert_channel_qradar.example.communication_type
 }

--- a/integration/resource_lacework_alert_channel_ibm_qradar_test.go
+++ b/integration/resource_lacework_alert_channel_ibm_qradar_test.go
@@ -1,0 +1,73 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIbmQRadarAlertChannelCreate applies integration terraform '../examples/resource_lacework_alert_channel_qradar'
+// Uses the go-sdk to verify the created integration
+// Applies an update with new channel name and Terraform destroy
+func TestIbmQRadarAlertChannelCreate(t *testing.T) {
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/resource_lacework_alert_channel_qradar",
+		Vars: map[string]interface{}{
+			"channel_name":       "IbmQRadar Alert Channel Example",
+			"host_url":           "https://qradar-lacework.com",
+			"host_port":          4000,
+			"communication_type": "HTTPS",
+		},
+	})
+	defer terraform.Destroy(t, terraformOptions)
+
+	// Create new IbmQRadar Alert Channel
+	create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+	created := GetAlertChannelProps(create)
+	data, ok := created.Data.Data.(map[string]interface{})
+	assert.True(t, ok)
+
+	actualName := terraform.Output(t, terraformOptions, "channel_name")
+	actualHost := terraform.Output(t, terraformOptions, "host_url")
+	actualPort := terraform.Output(t, terraformOptions, "host_port")
+	actualComm := terraform.Output(t, terraformOptions, "communication_type")
+
+	assert.Equal(t, "IbmQRadar Alert Channel Example", created.Data.Name)
+	assert.Equal(t, "https://qradar-lacework.com", data["qradarHostUrl"])
+	assert.Equal(t, float64(4000), data["qradarHostPort"])
+	assert.Equal(t, "HTTPS", data["qradarCommType"])
+
+	assert.Equal(t, "IbmQRadar Alert Channel Example", actualName)
+	assert.Equal(t, "https://qradar-lacework.com", actualHost)
+	assert.Equal(t, "4000", actualPort)
+	assert.Equal(t, "HTTPS", actualComm)
+
+	// Update IbmQRadar Alert Channel
+	terraformOptions.Vars = map[string]interface{}{
+		"channel_name":       "IbmQRadar Alert Channel Updated",
+		"host_url":           "https://qradar-lacework.com/updated",
+		"host_port":          80,
+		"communication_type": "HTTPS Self Signed Cert",
+	}
+
+	update := terraform.Apply(t, terraformOptions)
+	updated := GetAlertChannelProps(update)
+	data, ok = updated.Data.Data.(map[string]interface{})
+	assert.True(t, ok)
+
+	actualName = terraform.Output(t, terraformOptions, "channel_name")
+	actualHost = terraform.Output(t, terraformOptions, "host_url")
+	actualPort = terraform.Output(t, terraformOptions, "host_port")
+	actualComm = terraform.Output(t, terraformOptions, "communication_type")
+
+	assert.Equal(t, "IbmQRadar Alert Channel Updated", updated.Data.Name)
+	assert.Equal(t, "https://qradar-lacework.com/updated", data["qradarHostUrl"])
+	assert.Equal(t, float64(80), data["qradarHostPort"])
+	assert.Equal(t, "HTTPS Self Signed Cert", data["qradarCommType"])
+
+	assert.Equal(t, "IbmQRadar Alert Channel Updated", actualName)
+	assert.Equal(t, "https://qradar-lacework.com/updated", actualHost)
+	assert.Equal(t, "80", actualPort)
+	assert.Equal(t, "HTTPS Self Signed Cert", actualComm)
+}

--- a/lacework/resource_lacework_alert_channel_qradar.go
+++ b/lacework/resource_lacework_alert_channel_qradar.go
@@ -16,27 +16,26 @@ func resourceLaceworkAlertChannelQRadar() *schema.Resource {
 		Delete: resourceLaceworkAlertChannelQRadarDelete,
 
 		Importer: &schema.ResourceImporter{
-			State: importLaceworkIntegration,
+			State: importLaceworkAlertChannel,
 		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"intg_guid": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The integration name",
 			},
 			"enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "The state of the external integration",
 			},
 			"communication_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  string(api.QRadarCommHttps),
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The communication protocol used",
+				Default:     string(api.QRadarCommHttps),
 				ValidateFunc: func(value interface{}, key string) ([]string, []error) {
 					switch value.(string) {
 					case string(api.QRadarCommHttps), string(api.QRadarCommHttpsSelfSigned):
@@ -52,12 +51,14 @@ func resourceLaceworkAlertChannelQRadar() *schema.Resource {
 				},
 			},
 			"host_url": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The domain name or IP address of QRadar",
 			},
 			"host_port": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The listen port defined in QRadar",
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					v := val.(int)
 					if v < 0 || v > 65536 {
@@ -71,6 +72,10 @@ func resourceLaceworkAlertChannelQRadar() *schema.Resource {
 				Optional:    true,
 				Default:     true,
 				Description: "Whether to test the integration of an alert channel upon creation or modification",
+			},
+			"intg_guid": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"created_or_updated_time": {
 				Type:     schema.TypeString,
@@ -97,11 +102,12 @@ func resourceLaceworkAlertChannelQRadarCreate(d *schema.ResourceData, meta inter
 
 	var (
 		lacework = meta.(*api.Client)
-		qradar   = api.NewQRadarAlertChannel(d.Get("name").(string),
-			api.QRadarChannelData{
-				HostURL:           d.Get("host_url").(string),
-				HostPort:          d.Get("host_port").(int),
-				CommunicationType: comm,
+		qradar   = api.NewAlertChannel(d.Get("name").(string),
+			api.IbmQRadarAlertChannelType,
+			api.IbmQRadarDataV2{
+				HostURL:        d.Get("host_url").(string),
+				HostPort:       d.Get("host_port").(int),
+				QRadarCommType: comm,
 			},
 		)
 	)
@@ -109,70 +115,58 @@ func resourceLaceworkAlertChannelQRadarCreate(d *schema.ResourceData, meta inter
 		qradar.Enabled = 0
 	}
 
-	log.Printf("[INFO] Creating %s integration with data:\n%+v\n", api.QRadarChannelIntegration, qradar)
-	response, err := lacework.Integrations.CreateQRadarAlertChannel(qradar)
+	log.Printf("[INFO] Creating %s integration with data:\n%+v\n", api.IbmQRadarAlertChannelType, qradar)
+	response, err := lacework.V2.AlertChannels.Create(qradar)
 	if err != nil {
 		return err
 	}
 
-	log.Println("[INFO] Verifying server response data")
-	err = validateQRadarAlertChannelResponse(&response)
-	if err != nil {
-		return err
-	}
-
-	integration := response.Data[0]
+	integration := response.Data
 	d.SetId(integration.IntgGuid)
 	d.Set("name", integration.Name)
 	d.Set("intg_guid", integration.IntgGuid)
 	d.Set("enabled", integration.Enabled == 1)
 	d.Set("created_or_updated_time", integration.CreatedOrUpdatedTime)
 	d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
-	d.Set("type_name", integration.TypeName)
+	d.Set("type_name", integration.Type)
 	d.Set("org_level", integration.IsOrg == 1)
 
 	if d.Get("test_integration").(bool) {
-		log.Printf("[INFO] Testing %s integration for guid %s\n", api.QRadarChannelIntegration, d.Id())
+		log.Printf("[INFO] Testing %s integration for guid %s\n", api.IbmQRadarAlertChannelType, d.Id())
 		err := VerifyAlertChannelAndRollback(d, lacework)
 		if err != nil {
 			return err
 		}
-		log.Printf("[INFO] Tested %s integration with guid %s successfully\n", api.QRadarChannelIntegration, d.Id())
+		log.Printf("[INFO] Tested %s integration with guid %s successfully\n", api.IbmQRadarAlertChannelType, d.Id())
 	}
 
-	log.Printf("[INFO] Created %s integration with guid %s\n", api.QRadarChannelIntegration, integration.IntgGuid)
+	log.Printf("[INFO] Created %s integration with guid %s\n", api.IbmQRadarAlertChannelType, integration.IntgGuid)
 	return nil
 }
 
 func resourceLaceworkAlertChannelQRadarRead(d *schema.ResourceData, meta interface{}) error {
 	lacework := meta.(*api.Client)
 
-	log.Printf("[INFO] Reading %s integration with guid %s\n", api.QRadarChannelIntegration, d.Id())
-	response, err := lacework.Integrations.GetQRadarAlertChannel(d.Id())
+	log.Printf("[INFO] Reading %s integration with guid %s\n", api.IbmQRadarAlertChannelType, d.Id())
+	response, err := lacework.V2.AlertChannels.GetIbmQRadar(d.Id())
 	if err != nil {
 		return err
 	}
 
-	for _, integration := range response.Data {
-		if integration.IntgGuid == d.Id() {
-			d.Set("name", integration.Name)
-			d.Set("intg_guid", integration.IntgGuid)
-			d.Set("enabled", integration.Enabled == 1)
-			d.Set("created_or_updated_time", integration.CreatedOrUpdatedTime)
-			d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
-			d.Set("type_name", integration.TypeName)
-			d.Set("org_level", integration.IsOrg == 1)
-			d.Set("host_url", integration.Data.HostURL)
-			d.Set("host_port", integration.Data.HostPort)
-			d.Set("communicaton_type", integration.Data.CommunicationType)
+	integration := response.Data
+	d.Set("name", integration.Name)
+	d.Set("intg_guid", integration.IntgGuid)
+	d.Set("enabled", integration.Enabled == 1)
+	d.Set("created_or_updated_time", integration.CreatedOrUpdatedTime)
+	d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
+	d.Set("type_name", integration.Type)
+	d.Set("org_level", integration.IsOrg == 1)
+	d.Set("host_url", integration.Data.HostURL)
+	d.Set("host_port", integration.Data.HostPort)
+	d.Set("communicaton_type", integration.Data.QRadarCommType)
 
-			log.Printf("[INFO] Read %s integration with guid %s\n",
-				api.QRadarChannelIntegration, integration.IntgGuid)
-			return nil
-		}
-	}
-
-	d.SetId("")
+	log.Printf("[INFO] Read %s integration with guid %s\n",
+		api.IbmQRadarAlertChannelType, integration.IntgGuid)
 	return nil
 }
 
@@ -181,11 +175,12 @@ func resourceLaceworkAlertChannelQRadarUpdate(d *schema.ResourceData, meta inter
 
 	var (
 		lacework = meta.(*api.Client)
-		qradar   = api.NewQRadarAlertChannel(d.Get("name").(string),
-			api.QRadarChannelData{
-				HostURL:           d.Get("host_url").(string),
-				HostPort:          d.Get("host_port").(int),
-				CommunicationType: comm,
+		qradar   = api.NewAlertChannel(d.Get("name").(string),
+			api.IbmQRadarAlertChannelType,
+			api.IbmQRadarDataV2{
+				HostURL:        d.Get("host_url").(string),
+				HostPort:       d.Get("host_port").(int),
+				QRadarCommType: comm,
 			},
 		)
 	)
@@ -196,76 +191,43 @@ func resourceLaceworkAlertChannelQRadarUpdate(d *schema.ResourceData, meta inter
 
 	qradar.IntgGuid = d.Id()
 
-	log.Printf("[INFO] Updating %s integration with data:\n%+v\n", api.QRadarChannelIntegration, qradar)
-	response, err := lacework.Integrations.UpdateQRadarAlertChannel(qradar)
+	log.Printf("[INFO] Updating %s integration with data:\n%+v\n", api.IbmQRadarAlertChannelType, qradar)
+	response, err := lacework.V2.AlertChannels.UpdateIbmQRadar(qradar)
 	if err != nil {
 		return err
 	}
 
-	log.Println("[INFO] Verifying server response data")
-	err = validateQRadarAlertChannelResponse(&response)
-	if err != nil {
-		return err
-	}
-
-	integration := response.Data[0]
+	integration := response.Data
 	d.Set("name", integration.Name)
 	d.Set("intg_guid", integration.IntgGuid)
 	d.Set("enabled", integration.Enabled == 1)
 	d.Set("created_or_updated_time", integration.CreatedOrUpdatedTime)
 	d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
-	d.Set("type_name", integration.TypeName)
+	d.Set("type_name", integration.Type)
 	d.Set("org_level", integration.IsOrg == 1)
 
 	if d.Get("test_integration").(bool) {
-		log.Printf("[INFO] Testing %s integration for guid %s\n", api.QRadarChannelIntegration, d.Id())
+		log.Printf("[INFO] Testing %s integration for guid %s\n", api.IbmQRadarAlertChannelType, d.Id())
 		err := lacework.V2.AlertChannels.Test(d.Id())
 		if err != nil {
 			return err
 		}
-		log.Printf("[INFO] Tested %s integration with guid %s successfully\n", api.QRadarChannelIntegration, d.Id())
+		log.Printf("[INFO] Tested %s integration with guid %s successfully\n", api.IbmQRadarAlertChannelType, d.Id())
 	}
 
-	log.Printf("[INFO] Updated %s integration with guid %s\n", api.QRadarChannelIntegration, d.Id())
+	log.Printf("[INFO] Updated %s integration with guid %s\n", api.IbmQRadarAlertChannelType, d.Id())
 	return nil
 }
 
 func resourceLaceworkAlertChannelQRadarDelete(d *schema.ResourceData, meta interface{}) error {
 	lacework := meta.(*api.Client)
 
-	log.Printf("[INFO] Deleting %s integration with guid %s\n", api.QRadarChannelIntegration, d.Id())
-	_, err := lacework.Integrations.Delete(d.Id())
+	log.Printf("[INFO] Deleting %s integration with guid %s\n", api.IbmQRadarAlertChannelType, d.Id())
+	err := lacework.V2.AlertChannels.Delete(d.Id())
 	if err != nil {
 		return err
 	}
 
-	log.Printf("[INFO] Deleted %s integration with guid %s\n", api.QRadarChannelIntegration, d.Id())
-	return nil
-}
-
-func validateQRadarAlertChannelResponse(response *api.QRadarAlertChannelResponse) error {
-	if len(response.Data) == 0 {
-		msg := `
-Unable to read sever response data. (empty 'data' field)
-
-This was an unexpected behavior, verify that your integration has been
-created successfully and report this issue to support@lacework.net
-`
-		return fmt.Errorf(msg)
-	}
-
-	if len(response.Data) > 1 {
-		msg := `
-There is more that one integration inside the server response data.
-
-List of integrations:
-`
-		for _, integration := range response.Data {
-			msg = msg + fmt.Sprintf("\t%s: %s\n", integration.IntgGuid, integration.Name)
-		}
-		msg = msg + unexpectedBehaviorMsg()
-		return fmt.Errorf(msg)
-	}
-
+	log.Printf("[INFO] Deleted %s integration with guid %s\n", api.IbmQRadarAlertChannelType, d.Id())
 	return nil
 }


### PR DESCRIPTION
***Issue***: https://lacework.atlassian.net/browse/ALLY-646 https://github.com/lacework/terraform-provider-lacework/issues/147

***Description:***
Migrate Ibm QRadar alert channel to use api v2