### PR TITLE
fix: Migrate NewRelic Insights alert channel(v2)

### DIFF
--- a/examples/resource_lacework_alert_channel_newrelic/main.tf
+++ b/examples/resource_lacework_alert_channel_newrelic/main.tf
@@ -1,7 +1,45 @@
-provider "lacework" {}
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
 
 resource "lacework_alert_channel_newrelic" "example" {
-  name       = "My New Relic Insights Channel Alert Example"
-  account_id = 2338053
-  insert_key = "x-xx-xxxxxxxxxxxxxxxxxx"
+  name       = var.channel_name
+  account_id = var.account_id
+  insert_key = var.insert_key
+  // test_integration input is used in this example only for testing
+  // purposes, it help us avoid sending a "test" request to the
+  // system we are integrating to. In production, this should remain
+  // turned on ("true") which is the default setting
+  test_integration = false
+}
+
+variable "channel_name" {
+  type    = string
+  default = "NewRelic Insights Channel Alert Example"
+}
+
+variable "account_id" {
+  type    = number
+  default = 2338053
+}
+
+variable "insert_key" {
+  type    = string
+  default = "x-xx-xxxxxxxxxxxxxxxxxx"
+}
+
+output "channel_name" {
+  value = lacework_alert_channel_newrelic.example.name
+}
+
+output "account_id" {
+  value = lacework_alert_channel_newrelic.example.account_id
+}
+
+output "insert_key" {
+  value = lacework_alert_channel_newrelic.example.insert_key
 }

--- a/integration/resource_lacework_integration_newrelic_test.go
+++ b/integration/resource_lacework_integration_newrelic_test.go
@@ -1,0 +1,65 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewRelicAlertChannelCreate applies integration terraform '../examples/resource_lacework_alert_channel_newrelic'
+// Uses the go-sdk to verify the created integration
+// Applies an update with new channel name and Terraform destroy
+func TestNewRelicAlertChannelCreate(t *testing.T) {
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/resource_lacework_alert_channel_newrelic",
+		Vars: map[string]interface{}{
+			"channel_name": "NewRelic Insights Alert Channel Example",
+			"insert_key":   "x-xx-xxxxxxxxxxxxxxxxxx",
+			"account_id":   2338053,
+		},
+	})
+	defer terraform.Destroy(t, terraformOptions)
+
+	// Create new NewRelic Insights Alert Channel
+	create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+	created := GetAlertChannelProps(create)
+	data, ok := created.Data.Data.(map[string]interface{})
+	assert.True(t, ok)
+
+	actualName := terraform.Output(t, terraformOptions, "channel_name")
+	actualInsertKey := terraform.Output(t, terraformOptions, "insert_key")
+	actualAccountID := terraform.Output(t, terraformOptions, "account_id")
+
+	assert.Equal(t, "NewRelic Insights Alert Channel Example", created.Data.Name)
+	assert.Equal(t, "x-xx-xxxxxxxxxxxxxxxxxx", data["insertKey"])
+	assert.Equal(t, float64(2.338053e+06), data["accountId"])
+
+	assert.Equal(t, "NewRelic Insights Alert Channel Example", actualName)
+	assert.Equal(t, "x-xx-xxxxxxxxxxxxxxxxxx", actualInsertKey)
+	assert.Equal(t, "2.338053e+06", actualAccountID)
+
+	// Update NewRelic Insights Alert Channel
+	terraformOptions.Vars = map[string]interface{}{
+		"channel_name": "NewRelic Insights Alert Channel Updated",
+		"insert_key":   "x-xx-xxxxxxxxxxxxxxxxxy",
+		"account_id":   1338053,
+	}
+
+	update := terraform.Apply(t, terraformOptions)
+	updated := GetAlertChannelProps(update)
+	data, ok = updated.Data.Data.(map[string]interface{})
+	assert.True(t, ok)
+
+	actualName = terraform.Output(t, terraformOptions, "channel_name")
+	actualInsertKey = terraform.Output(t, terraformOptions, "insert_key")
+	actualAccountID = terraform.Output(t, terraformOptions, "account_id")
+
+	assert.Equal(t, "NewRelic Insights Alert Channel Updated", updated.Data.Name)
+	assert.Equal(t, "x-xx-xxxxxxxxxxxxxxxxxy", data["insertKey"])
+	assert.Equal(t, float64(1.338053e+06), data["accountId"])
+
+	assert.Equal(t, "NewRelic Insights Alert Channel Updated", actualName)
+	assert.Equal(t, "x-xx-xxxxxxxxxxxxxxxxxy", actualInsertKey)
+	assert.Equal(t, "1.338053e+06", actualAccountID)
+}


### PR DESCRIPTION
***Issue***: https://lacework.atlassian.net/browse/ALLY-645 https://github.com/lacework/terraform-provider-lacework/issues/147

***Description:***
Migrate New Relic Insights alert channel to use api v2