### PR TITLE
test: fix tests for alert_rule resource

### DIFF
--- a/examples/resource_lacework_alert_rule/main.tf
+++ b/examples/resource_lacework_alert_rule/main.tf
@@ -12,37 +12,37 @@ resource "lacework_alert_rule" "example" {
   channels         = var.channels
   severities       = var.severities
   event_categories = var.event_categories
-  resource_groups  = var.resource_groups
+  resource_groups  = [lacework_resource_group_aws.example.id]
+}
+
+resource "lacework_resource_group_aws" "example" {
+  name     = "Users for Aler Rules Testing"
+  accounts = ["*"]
 }
 
 variable "name" {
-type    = string
-default = "Alert Rule"
+  type    = string
+  default = "Alert Rule"
 }
 
 variable "description" {
-type    = string
-default = "Alert Rule created by Terraform"
+  type    = string
+  default = "Alert Rule created by Terraform"
 }
 
 variable "channels" {
-type    = list(string)
-default = ["TECHALLY_AB90D4E77C93A9DE0DF6B22B9B06B9934645D6027C9D350"]
+  type    = list(string)
+  default = ["TECHALLY_AB90D4E77C93A9DE0DF6B22B9B06B9934645D6027C9D350"]
 }
 
 variable "severities" {
-type    = list(string)
-default = ["High", "Medium"]
+  type    = list(string)
+  default = ["High", "Medium"]
 }
 
 variable "event_categories" {
-type    = list(string)
-default = ["Compliance"]
-}
-
-variable "resource_groups" {
-type    = list(string)
-default = ["TECHALLY_528AA69075E54C783DCFAB0B76BE919287639FBAF26101B"]
+  type    = list(string)
+  default = ["Compliance"]
 }
 
 output "name" {
@@ -65,6 +65,6 @@ output "event_categories" {
   value = lacework_alert_rule.example.event_categories
 }
 
-output "resource_groups" {
-  value = lacework_alert_rule.example.resource_groups
+output "resource_group_id" {
+  value = lacework_resource_group_aws.example.id
 }

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -157,7 +157,7 @@ func GetAlertChannelProps(result string) api.AlertChannelResponse {
 }
 
 func GetAlertRuleProps(result string) api.AlertRuleResponse {
-	id := GetIDFromTerraResults(result)
+	id := GetSpecificIDFromTerraResults(2, result)
 
 	var data api.AlertRuleResponse
 	err := LwClient.V2.AlertRules.Get(id, &data)
@@ -167,11 +167,17 @@ func GetAlertRuleProps(result string) api.AlertRuleResponse {
 	return data
 }
 
-func GetIDFromTerraResults(result string) string {
+// GetSpecificIDFromTerraResults returns the specific index id found in the Terraform output
+func GetSpecificIDFromTerraResults(i int, result string) string {
 	re := regexp.MustCompile("\\[id=(.*?)\\]")
-	match := re.FindStringSubmatch(result)
-	if len(match) >= 2 {
-		return match[1]
+	match := re.FindAllStringSubmatch(result, -1)
+	if len(match) >= i {
+		return match[i-1][1]
 	}
 	return ""
+}
+
+// GetIDFromTerraResults returns the first id found in the Terraform output
+func GetIDFromTerraResults(result string) string {
+	return GetSpecificIDFromTerraResults(1, result)
 }


### PR DESCRIPTION
***Issue***:  N/A

***Description:***
This PR fixes the Alert Rules tests:

- The validate tests were not working since we were using the wrong terratest func
- Removed hardcoded Resource Group ID and added a resource to create it at run time