### PR TITLE
ci: improve unit and integration test output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ website/node_modules
 log.txt
 
 website/vendor
+coverage.out
 
 # Test exclusions
 !command/test-fixtures/**/*.tfstate

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,6 +2,7 @@
 GOLANGCILINTVERSION?=1.23.8
 GOIMPORTSVERSION?=v0.1.2
 GOXVERSION?=v1.0.1
+GOTESTSUMVERSION?=v1.6.4
 
 TEST?=$$(go list ./... |grep -v 'vendor' | grep -v 'integration')
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
@@ -78,13 +79,11 @@ uninstall: ## Removes installed provider package from BINARY_PATH
 
 .PHONY: integration-test
 integration-test: clean-test install ## Runs clean-test and install, then runs all integration tests
-	go test ./integration -v
+	gotestsum -f testname -- -v ./integration
 
 .PHONY: test
 test: fmtcheck ## Runs fmtcheck then runs all unit tests
-	go test $(TEST) || exit 1
-	echo $(TEST) | \
-		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
+	gotestsum -f testname -- -v -cover -coverprofile=$(COVERAGEOUT) $(TEST)
 
 .PHONY: lint
 lint: ## Runs go linter
@@ -151,6 +150,9 @@ ifeq (, $(shell which goimports))
 endif
 ifeq (, $(shell which gox))
 	GOFLAGS=-mod=readonly go install github.com/mitchellh/gox@$(GOXVERSION)
+endif
+ifeq (, $(shell which gotestsum))
+	GOFLAGS=-mod=readonly go install gotest.tools/gotestsum@$(GOTESTSUMVERSION)
 endif
 
 .PHONY: write-terraform-rc


### PR DESCRIPTION
The current test output is hard to read since there are a number of tests now, to find
an error you have to scroll and CodeFresh scrolling is really really slow.

This change implements **gotestsum** to run the tests and print a summary at the end
of the execution of the test.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>