### PR TITLE
test: create unique names for resource groups integration tests

### DIFF
--- a/integration/resource_lacework_resource_group_account_test.go
+++ b/integration/resource_lacework_resource_group_account_test.go
@@ -20,8 +20,8 @@ func TestResourceGroupLwAccountCreate(t *testing.T) {
 		TerraformDir: "../examples/resource_lacework_resource_group_account",
 		Vars: map[string]interface{}{
 			"resource_group_name": name,
-			"description": "Terraform Test LwAccount Resource Group",
-			"lw_accounts": []string{"tech-ally"},
+			"description":         "Terraform Test LwAccount Resource Group",
+			"lw_accounts":         []string{"tech-ally"},
 		},
 	})
 	defer terraform.Destroy(t, terraformOptions)

--- a/integration/resource_lacework_resource_group_account_test.go
+++ b/integration/resource_lacework_resource_group_account_test.go
@@ -1,7 +1,9 @@
 package integration
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
@@ -13,9 +15,11 @@ import (
 // It uses the go-sdk to verify the created resource group,
 // applies an update with new description and destroys it
 func TestResourceGroupLwAccountCreate(t *testing.T) {
+	name := fmt.Sprintf("Terraform Test LwAccount Resource Group - %s", time.Now())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_resource_group_account",
 		Vars: map[string]interface{}{
+			"resource_group_name": name,
 			"description": "Terraform Test LwAccount Resource Group",
 			"lw_accounts": []string{"tech-ally"},
 		},

--- a/integration/resource_lacework_resource_group_aws_test.go
+++ b/integration/resource_lacework_resource_group_aws_test.go
@@ -1,7 +1,9 @@
 package integration
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
@@ -13,9 +15,11 @@ import (
 // It uses the go-sdk to verify the created resource group,
 // applies an update with new description and destroys it
 func TestResourceGroupAwsCreate(t *testing.T) {
+	name := fmt.Sprintf("Terraform Test Aws Resource Group - %s", time.Now())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_resource_group_aws",
 		Vars: map[string]interface{}{
+			"resource_group_name": name,
 			"description": "Terraform Test Aws Resource Group",
 		},
 	})

--- a/integration/resource_lacework_resource_group_aws_test.go
+++ b/integration/resource_lacework_resource_group_aws_test.go
@@ -20,7 +20,7 @@ func TestResourceGroupAwsCreate(t *testing.T) {
 		TerraformDir: "../examples/resource_lacework_resource_group_aws",
 		Vars: map[string]interface{}{
 			"resource_group_name": name,
-			"description": "Terraform Test Aws Resource Group",
+			"description":         "Terraform Test Aws Resource Group",
 		},
 	})
 	defer terraform.Destroy(t, terraformOptions)

--- a/integration/resource_lacework_resource_group_azure_test.go
+++ b/integration/resource_lacework_resource_group_azure_test.go
@@ -20,9 +20,9 @@ func TestResourceGroupAzureCreate(t *testing.T) {
 		TerraformDir: "../examples/resource_lacework_resource_group_azure",
 		Vars: map[string]interface{}{
 			"resource_group_name": name,
-			"description":   "Terraform Test Azure Resource Group",
-			"tenant":        "b21aa1ab-111a-11ab-a000-11aa1111a11a",
-			"subscriptions": []string{"1a1a0b2-abc0-1ab1-1abc-1a000ab0a0a0"},
+			"description":         "Terraform Test Azure Resource Group",
+			"tenant":              "b21aa1ab-111a-11ab-a000-11aa1111a11a",
+			"subscriptions":       []string{"1a1a0b2-abc0-1ab1-1abc-1a000ab0a0a0"},
 		},
 	})
 	defer terraform.Destroy(t, terraformOptions)

--- a/integration/resource_lacework_resource_group_azure_test.go
+++ b/integration/resource_lacework_resource_group_azure_test.go
@@ -1,7 +1,9 @@
 package integration
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
@@ -13,9 +15,11 @@ import (
 // It uses the go-sdk to verify the created resource group,
 // applies an update with new description and destroys it
 func TestResourceGroupAzureCreate(t *testing.T) {
+	name := fmt.Sprintf("Terraform Test Azure Resource Group - %s", time.Now())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_resource_group_azure",
 		Vars: map[string]interface{}{
+			"resource_group_name": name,
 			"description":   "Terraform Test Azure Resource Group",
 			"tenant":        "b21aa1ab-111a-11ab-a000-11aa1111a11a",
 			"subscriptions": []string{"1a1a0b2-abc0-1ab1-1abc-1a000ab0a0a0"},

--- a/integration/resource_lacework_resource_group_container_test.go
+++ b/integration/resource_lacework_resource_group_container_test.go
@@ -1,7 +1,9 @@
 package integration
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
@@ -13,9 +15,11 @@ import (
 // It uses the go-sdk to verify the created resource group,
 // applies an update with new description and destroys it
 func TestResourceGroupContainerCreate(t *testing.T) {
+	name := fmt.Sprintf("Terraform Test Machine Resource Group - %s", time.Now())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_resource_group_container",
 		Vars: map[string]interface{}{
+			"resource_group_name": name,
 			"description": "Terraform Test Container Resource Group",
 			"ctr_tags":    []string{"test-tag"},
 			"ctr_key":     "test-key",

--- a/integration/resource_lacework_resource_group_container_test.go
+++ b/integration/resource_lacework_resource_group_container_test.go
@@ -20,10 +20,10 @@ func TestResourceGroupContainerCreate(t *testing.T) {
 		TerraformDir: "../examples/resource_lacework_resource_group_container",
 		Vars: map[string]interface{}{
 			"resource_group_name": name,
-			"description": "Terraform Test Container Resource Group",
-			"ctr_tags":    []string{"test-tag"},
-			"ctr_key":     "test-key",
-			"ctr_value":   "test-value",
+			"description":         "Terraform Test Container Resource Group",
+			"ctr_tags":            []string{"test-tag"},
+			"ctr_key":             "test-key",
+			"ctr_value":           "test-value",
 		},
 	})
 	defer terraform.Destroy(t, terraformOptions)

--- a/integration/resource_lacework_resource_group_gcp_test.go
+++ b/integration/resource_lacework_resource_group_gcp_test.go
@@ -20,9 +20,9 @@ func TestResourceGroupGcpCreate(t *testing.T) {
 		TerraformDir: "../examples/resource_lacework_resource_group_gcp",
 		Vars: map[string]interface{}{
 			"resource_group_name": name,
-			"description":  "Terraform Test Gcp Resource Group",
-			"organization": "MyGcpOrg",
-			"projects":     []string{"pro-123", "pro-321"},
+			"description":         "Terraform Test Gcp Resource Group",
+			"organization":        "MyGcpOrg",
+			"projects":            []string{"pro-123", "pro-321"},
 		},
 	})
 	defer terraform.Destroy(t, terraformOptions)

--- a/integration/resource_lacework_resource_group_gcp_test.go
+++ b/integration/resource_lacework_resource_group_gcp_test.go
@@ -1,7 +1,9 @@
 package integration
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
@@ -13,9 +15,11 @@ import (
 // It uses the go-sdk to verify the created resource group,
 // applies an update with new description and destroys it
 func TestResourceGroupGcpCreate(t *testing.T) {
+	name := fmt.Sprintf("Terraform Test LwAccount Resource Group - %s", time.Now())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_resource_group_gcp",
 		Vars: map[string]interface{}{
+			"resource_group_name": name,
 			"description":  "Terraform Test Gcp Resource Group",
 			"organization": "MyGcpOrg",
 			"projects":     []string{"pro-123", "pro-321"},

--- a/integration/resource_lacework_resource_group_machine_test.go
+++ b/integration/resource_lacework_resource_group_machine_test.go
@@ -1,7 +1,9 @@
 package integration
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
@@ -13,9 +15,11 @@ import (
 // It uses the go-sdk to verify the created resource group,
 // applies an update with new description and destroys it
 func TestResourceGroupMachineCreate(t *testing.T) {
+	name := fmt.Sprintf("Terraform Test Machine Resource Group - %s", time.Now())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_resource_group_machine",
 		Vars: map[string]interface{}{
+			"resource_group_name": name,
 			"description":   "Terraform Test Machine Resource Group",
 			"machine_key":   "test-key",
 			"machine_value": "test-value",

--- a/integration/resource_lacework_resource_group_machine_test.go
+++ b/integration/resource_lacework_resource_group_machine_test.go
@@ -20,9 +20,9 @@ func TestResourceGroupMachineCreate(t *testing.T) {
 		TerraformDir: "../examples/resource_lacework_resource_group_machine",
 		Vars: map[string]interface{}{
 			"resource_group_name": name,
-			"description":   "Terraform Test Machine Resource Group",
-			"machine_key":   "test-key",
-			"machine_value": "test-value",
+			"description":         "Terraform Test Machine Resource Group",
+			"machine_key":         "test-key",
+			"machine_value":       "test-value",
 		},
 	})
 	defer terraform.Destroy(t, terraformOptions)


### PR DESCRIPTION

***Issue***: [Include link to the Jira/Github Issue](https://lacework.atlassian.net/browse/ALLY-705)

***Description:***
Avoid conflicts in integration tests by setting unique names
