### PR TITLE
fix: remove apiIntgKey from resourceLaceworkAlertChannelPagerDutyRead

### DIFF
--- a/integration/resource_lacework_integration_pagerduty_test.go
+++ b/integration/resource_lacework_integration_pagerduty_test.go
@@ -29,7 +29,7 @@ func TestPagerDutyAlertChannelCreate(t *testing.T) {
 	actualName := terraform.Output(t, terraformOptions, "channel_name")
 
 	assert.Equal(t, "PagerDuty Alert Channel Example", created.Data.Name)
-	assert.Equal(t, "1234abc8901abc567abc123abc78e012", data["apiIntgKey"])
+	assert.Equal(t, "", data["apiIntgKey"])
 
 	assert.Equal(t, "PagerDuty Alert Channel Example", actualName)
 
@@ -47,7 +47,7 @@ func TestPagerDutyAlertChannelCreate(t *testing.T) {
 	actualName = terraform.Output(t, terraformOptions, "channel_name")
 
 	assert.Equal(t, "PagerDuty Alert Channel Updated", updated.Data.Name)
-	assert.Equal(t, "1234abc8901abc567abc123abc78e013", data["apiIntgKey"])
+	assert.Equal(t, "", data["apiIntgKey"])
 
 	assert.Equal(t, "PagerDuty Alert Channel Updated", actualName)
 }

--- a/lacework/resource_lacework_alert_channel_pagerduty.go
+++ b/lacework/resource_lacework_alert_channel_pagerduty.go
@@ -127,7 +127,6 @@ func resourceLaceworkAlertChannelPagerDutyRead(d *schema.ResourceData, meta inte
 	d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
 	d.Set("type_name", integration.Type)
 	d.Set("org_level", integration.IsOrg == 1)
-	d.Set("integration_key", integration.Data.IntegrationKey)
 
 	log.Printf("[INFO] Read %s integration with guid %s\n",
 		api.PagerDutyApiAlertChannelType, integration.IntgGuid)


### PR DESCRIPTION
***Description:***
PagerDuty Api has been updated to return apiIntgKey as empty string, this change removes apiIntgKey from resourceLaceworkAlertChannelPagerDutyRead and amends test assertions.