### PR TITLE
test: skip org test for lw account resource group

### DIFF
--- a/integration/resource_lacework_resource_group_account_test.go
+++ b/integration/resource_lacework_resource_group_account_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -15,6 +16,9 @@ import (
 // It uses the go-sdk to verify the created resource group,
 // applies an update with new description and destroys it
 func TestResourceGroupLwAccountCreate(t *testing.T) {
+	if os.Getenv("CI_STANDALONE_ACCOUNT") != "" {
+		t.Skip("skipping organizational account test")
+	}
 	name := fmt.Sprintf("Terraform Test LwAccount Resource Group - %s", time.Now())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_resource_group_account",


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-provider-lacework/blob/main/CONTRIBUTING.md
--->

***Issue***: N/A

***Description:***
Skipping organization test for Standalone accounts.

***Additional Info:***
Our QA pipelines are failing trying to run this test when the Lacework account is not an Organization.