### PR TITLE
feat: new lacework_policy resource

### DIFF
--- a/examples/resource_lacework_policy/main.tf
+++ b/examples/resource_lacework_policy/main.tf
@@ -1,0 +1,89 @@
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+resource "lacework_policy" "example" {
+  title            = var.title
+  query_id         = "LW_Global_AWS_CTA_CloudTrailChange"
+  severity         = var.severity
+  type             = var.type
+  description      = var.description
+  remediation      = var.remediation
+  evaluation       = var.evaluation
+  evaluator_id     = "Cloudtrail"
+  enabled          = true
+  policy_id_suffix = var.policy_id_suffix
+
+  alerting {
+    enabled = false
+    profile = "LW_CloudTrail_Alerts"
+  }
+}
+
+
+variable "title" {
+  type    = string
+  default = "lql-terraform-policy"
+}
+
+variable "description" {
+  type    = string
+  default = "Policy Created via Terraform"
+}
+
+variable "severity" {
+  type    = string
+  default = "High"
+}
+
+variable "remediation" {
+  type    = string
+  default = "Please Investigate"
+}
+
+variable "type" {
+  type    = string
+  default = "Violation"
+}
+
+variable "evaluation" {
+  type    = string
+  default = "Hourly"
+}
+
+variable "policy_id_suffix" {
+  default = ""
+}
+
+output "title" {
+  value = lacework_policy.example.title
+}
+
+output "severity" {
+  value = lacework_policy.example.severity
+}
+
+output "remediation" {
+  value = lacework_policy.example.remediation
+}
+
+output "evaluation" {
+  value = lacework_policy.example.evaluation
+}
+
+output "type" {
+  value = lacework_policy.example.type
+}
+
+output "description" {
+  value = lacework_policy.example.description
+}
+
+output "policy_id_suffix" {
+  value = lacework_policy.example.policy_id_suffix
+}
+

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -229,3 +229,13 @@ func GetSpecificIDFromTerraResults(i int, result string) string {
 func GetIDFromTerraResults(result string) string {
 	return GetSpecificIDFromTerraResults(1, result)
 }
+
+func GetPolicyProps(result string) api.PolicyResponse {
+	id := GetSpecificIDFromTerraResults(1, result)
+
+	resp, err := LwClient.V2.Policy.Get(id)
+	if err != nil {
+		log.Fatalf("Unable to retrieve policy with id: %s", id)
+	}
+	return resp
+}

--- a/integration/resource_lacework_policy_test.go
+++ b/integration/resource_lacework_policy_test.go
@@ -1,0 +1,153 @@
+package integration
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPolicyCreate applies integration terraform:
+// => '../examples/resource_lacework_policy'
+//
+// It uses the go-sdk to verify the created policy,
+// applies an update and destroys it
+//nolint
+func TestPolicyCreate(t *testing.T) {
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/resource_lacework_policy",
+		Vars: map[string]interface{}{
+			"title":       "lql-terraform-policy",
+			"severity":    "High",
+			"type":        "Violation",
+			"description": "Policy Created via Terraform",
+			"remediation": "Please Investigate",
+			"evaluation":  "Hourly",
+		},
+	})
+	defer terraform.Destroy(t, terraformOptions)
+
+	// Create new Policy
+	create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+	createProps := GetPolicyProps(create)
+
+	actualTitle := terraform.Output(t, terraformOptions, "title")
+	actualSeverity := terraform.Output(t, terraformOptions, "severity")
+	actualType := terraform.Output(t, terraformOptions, "type")
+	actualDescription := terraform.Output(t, terraformOptions, "description")
+	actualRemediation := terraform.Output(t, terraformOptions, "remediation")
+	actualEvaluation := terraform.Output(t, terraformOptions, "evaluation")
+
+	assert.Contains(t, "lql-terraform-policy", createProps.Data.Title)
+	assert.Contains(t, "high", createProps.Data.Severity)
+	assert.Contains(t, "Violation", createProps.Data.PolicyType)
+	assert.Contains(t, "Policy Created via Terraform", createProps.Data.Description)
+	assert.Contains(t, "Please Investigate", createProps.Data.Remediation)
+	assert.Contains(t, "Hourly", createProps.Data.EvalFrequency)
+
+	assert.Equal(t, "lql-terraform-policy", actualTitle)
+	assert.Equal(t, "high", actualSeverity)
+	assert.Equal(t, "Violation", actualType)
+	assert.Equal(t, "Policy Created via Terraform", actualDescription)
+	assert.Equal(t, "Please Investigate", actualRemediation)
+	assert.Equal(t, "Hourly", actualEvaluation)
+
+	// Update Policy
+	terraformOptions.Vars = map[string]interface{}{
+		"title":       "lql-terraform-policy-updated",
+		"severity":    "Low",
+		"type":        "Summary",
+		"description": "Policy Created via Terraform Updated",
+		"remediation": "Please Ignore",
+		"evaluation":  "Daily",
+	}
+
+	update := terraform.ApplyAndIdempotent(t, terraformOptions)
+	updateProps := GetPolicyProps(update)
+
+	actualTitle = terraform.Output(t, terraformOptions, "title")
+	actualSeverity = terraform.Output(t, terraformOptions, "severity")
+	actualType = terraform.Output(t, terraformOptions, "type")
+	actualDescription = terraform.Output(t, terraformOptions, "description")
+	actualRemediation = terraform.Output(t, terraformOptions, "remediation")
+	actualEvaluation = terraform.Output(t, terraformOptions, "evaluation")
+
+	assert.Contains(t, "lql-terraform-policy-updated", updateProps.Data.Title)
+	assert.Contains(t, "low", updateProps.Data.Severity)
+	assert.Contains(t, "Summary", updateProps.Data.PolicyType)
+	assert.Contains(t, "Policy Created via Terraform Updated", updateProps.Data.Description)
+	assert.Contains(t, "Please Ignore", updateProps.Data.Remediation)
+	assert.Contains(t, "Daily", updateProps.Data.EvalFrequency)
+
+	assert.Equal(t, "lql-terraform-policy-updated", actualTitle)
+	assert.Equal(t, "low", actualSeverity)
+	assert.Equal(t, "Summary", actualType)
+	assert.Equal(t, "Policy Created via Terraform Updated", actualDescription)
+	assert.Equal(t, "Please Ignore", actualRemediation)
+	assert.Equal(t, "Daily", actualEvaluation)
+}
+
+func TestPolicyCreateWithPolicyIDSuffix(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+	suffix := fmt.Sprintf("terraform-%d", rand.Intn(1000))
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/resource_lacework_policy",
+		Vars: map[string]interface{}{
+			"title":            "lql-terraform-policy",
+			"policy_id_suffix": suffix,
+			"severity":         "High",
+			"type":             "Violation",
+			"description":      "Policy Created via Terraform",
+			"remediation":      "Please Investigate",
+			"evaluation":       "Hourly",
+		},
+	})
+	defer terraform.Destroy(t, terraformOptions)
+
+	// Create new Policy
+	create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+	createProps := GetPolicyProps(create)
+
+	actualTitle := terraform.Output(t, terraformOptions, "title")
+	actualSeverity := terraform.Output(t, terraformOptions, "severity")
+	actualType := terraform.Output(t, terraformOptions, "type")
+	actualDescription := terraform.Output(t, terraformOptions, "description")
+	actualRemediation := terraform.Output(t, terraformOptions, "remediation")
+	actualEvaluation := terraform.Output(t, terraformOptions, "evaluation")
+	actualSuffix := terraform.Output(t, terraformOptions, "policy_id_suffix")
+
+	assert.Contains(t, "lql-terraform-policy", createProps.Data.Title)
+	assert.Contains(t, "high", createProps.Data.Severity)
+	assert.Contains(t, "Violation", createProps.Data.PolicyType)
+	assert.Contains(t, "Policy Created via Terraform", createProps.Data.Description)
+	assert.Contains(t, "Please Investigate", createProps.Data.Remediation)
+	assert.Contains(t, "Hourly", createProps.Data.EvalFrequency)
+
+	assert.Equal(t, "lql-terraform-policy", actualTitle)
+	assert.Equal(t, "high", actualSeverity)
+	assert.Equal(t, "Violation", actualType)
+	assert.Equal(t, "Policy Created via Terraform", actualDescription)
+	assert.Equal(t, "Please Investigate", actualRemediation)
+	assert.Equal(t, "Hourly", actualEvaluation)
+	assert.Contains(t, suffix, actualSuffix)
+
+	// Update Policy
+	terraformOptions.Vars = map[string]interface{}{
+		"title":            "lql-terraform-policy-updated",
+		"policy_id_suffix": "modified-id-suffix",
+		"severity":         "Low",
+		"type":             "Summary",
+		"description":      "Policy Created via Terraform Updated",
+		"remediation":      "Please Ignore",
+		"evaluation":       "Daily",
+	}
+
+	msg, err := terraform.ApplyE(t, terraformOptions)
+
+	assert.Error(t, err)
+	assert.Contains(t, msg, "unable to change ID of an existing policy")
+
+}

--- a/lacework/provider.go
+++ b/lacework/provider.go
@@ -93,6 +93,7 @@ func Provider() *schema.Provider {
 			"lacework_integration_gar":                   resourceLaceworkIntegrationGar(),
 			"lacework_integration_gcr":                   resourceLaceworkIntegrationGcr(),
 			"lacework_integration_ghcr":                  resourceLaceworkIntegrationGhcr(),
+			"lacework_policy":                            resourceLaceworkPolicy(),
 			"lacework_report_rule":                       resourceLaceworkReportRule(),
 			"lacework_resource_group_account":            resourceLaceworkResourceGroupLwAccount(),
 			"lacework_resource_group_aws":                resourceLaceworkResourceGroupAws(),

--- a/lacework/resource_lacework_policy.go
+++ b/lacework/resource_lacework_policy.go
@@ -1,0 +1,297 @@
+package lacework
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/lacework/go-sdk/api"
+)
+
+func resourceLaceworkPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLaceworkPolicyCreate,
+		Read:   resourceLaceworkPolicyRead,
+		Update: resourceLaceworkPolicyUpdate,
+		Delete: resourceLaceworkPolicyDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: importLaceworkPolicy,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"title": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The title of the policy",
+			},
+			"query_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The id of the query",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The description of the query",
+			},
+			"severity": {
+				Type:     schema.TypeString,
+				Required: true,
+				Description: "The severity for the policy. Valid severities are: " +
+					"Critical, High, Medium, Low, Info",
+				StateFunc: func(val interface{}) string {
+					return strings.TrimSpace(strings.ToLower(val.(string)))
+				},
+				ValidateDiagFunc: ValidSeverity(),
+			},
+			"evaluation": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The evaluation frequency must be either 'Hourly' or 'Daily'. Defaults to 'Hourly'.",
+				ValidateFunc: func(value interface{}, key string) ([]string, []error) {
+					switch value.(string) {
+					case "Hourly", "Daily":
+						return nil, nil
+					default:
+						return nil, []error{
+							fmt.Errorf(
+								"%s: can only be 'Hourly' or 'Daily'", key,
+							),
+						}
+					}
+				},
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The policy type must be either 'Violation' or 'Summary'. Defaults to 'Violation'.",
+				ValidateFunc: func(value interface{}, key string) ([]string, []error) {
+					switch value.(string) {
+					case "Violation", "Summary":
+						return nil, nil
+					default:
+						return nil, []error{
+							fmt.Errorf(
+								"%s: can only be 'Violation' or 'Summary'", key,
+							),
+						}
+					}
+				},
+			},
+			"policy_id_suffix": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The string appended to the end of the policy id",
+			},
+			"evaluator_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: "The policy evaluator id.",
+			},
+			"limit": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      1000,
+				ValidateFunc: validation.IntAtMost(1000),
+				Description:  "Set the maximum number of records returned by the policy. Maximum value is '1000'",
+			},
+			"remediation": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The remediation message to display",
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "The state of the policy",
+			},
+			"alerting": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "Alerting",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"profile": {
+							Type:        schema.TypeString,
+							Description: "The alerting profile",
+							Required:    true,
+						},
+						"enabled": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     true,
+							Description: "Whether alerting is enabled/disabled",
+						},
+					},
+				},
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"owner": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceLaceworkPolicyCreate(d *schema.ResourceData, meta interface{}) error {
+	var (
+		lacework = meta.(*api.Client)
+	)
+
+	policy := api.NewPolicy{
+		EvaluatorID:   d.Get("evaluator_id").(string),
+		PolicyType:    d.Get("type").(string),
+		QueryID:       d.Get("query_id").(string),
+		Title:         d.Get("title").(string),
+		Enabled:       d.Get("enabled").(bool),
+		Description:   d.Get("description").(string),
+		Remediation:   d.Get("remediation").(string),
+		Severity:      d.Get("severity").(string),
+		Limit:         d.Get("limit").(int),
+		EvalFrequency: d.Get("evaluation").(string),
+		AlertEnabled:  d.Get("alerting.0.enabled").(bool),
+		AlertProfile:  d.Get("alerting.0.profile").(string),
+		PolicyID:      d.Get("policy_id_suffix").(string),
+	}
+
+	log.Printf("[INFO] Creating Policy with data:\n%+v\n", policy)
+	response, err := lacework.V2.Policy.Create(policy)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(response.Data.PolicyID)
+	d.Set("owner", response.Data.Owner)
+	d.Set("updated_time", response.Data.LastUpdateTime)
+	d.Set("updated_by", response.Data.LastUpdateUser)
+
+	log.Printf("[INFO] Created Policy with guid %s\n", response.Data.PolicyID)
+	return nil
+}
+
+func resourceLaceworkPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	var (
+		lacework = meta.(*api.Client)
+	)
+
+	log.Printf("[INFO] Reading Policy with guid %s\n", d.Id())
+	response, err := lacework.V2.Policy.Get(d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.SetId(response.Data.PolicyID)
+	d.Set("title", response.Data.Title)
+	d.Set("query_id", response.Data.QueryID)
+	d.Set("evaluator_id", response.Data.EvaluatorID)
+	d.Set("enabled", response.Data.Enabled)
+	d.Set("description", response.Data.Description)
+	d.Set("evaluation", response.Data.EvalFrequency)
+	d.Set("severity", response.Data.Severity)
+	d.Set("remediation", response.Data.Remediation)
+	d.Set("limit", response.Data.Limit)
+	d.Set("type", response.Data.PolicyType)
+	d.Set("owner", response.Data.Owner)
+	d.Set("updated_time", response.Data.LastUpdateTime)
+	d.Set("updated_by", response.Data.LastUpdateUser)
+
+	alerting := make(map[string]interface{})
+	alerting["enabled"] = response.Data.AlertEnabled
+	alerting["profile"] = response.Data.AlertProfile
+	d.Set("alerting", alerting)
+
+	log.Printf("[INFO] Read Policy with guid %s\n", response.Data.PolicyID)
+	return nil
+}
+
+func resourceLaceworkPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+	var (
+		lacework = meta.(*api.Client)
+	)
+
+	if d.HasChange("policy_id_suffix") {
+		return errors.New("unable to change ID of an existing policy")
+	}
+
+	policyEnabled := d.Get("enabled").(bool)
+	alertingEnabled := d.Get("alerting.0.enabled").(bool)
+	policyLimit := d.Get("limit").(int)
+
+	policy := api.UpdatePolicy{
+		EvaluatorID:   d.Get("evaluator_id").(string),
+		PolicyType:    d.Get("type").(string),
+		QueryID:       d.Get("query_id").(string),
+		Title:         d.Get("title").(string),
+		Enabled:       &policyEnabled,
+		Description:   d.Get("description").(string),
+		Remediation:   d.Get("remediation").(string),
+		Severity:      d.Get("severity").(string),
+		Limit:         &policyLimit,
+		EvalFrequency: d.Get("evaluation").(string),
+		AlertEnabled:  &alertingEnabled,
+		AlertProfile:  d.Get("alerting.0.profile").(string),
+		PolicyID:      d.Id(),
+	}
+
+	log.Printf("[INFO] Updating Policy with data:\n%+v\n", policy)
+	response, err := lacework.V2.Policy.Update(policy)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(response.Data.PolicyID)
+	d.Set("owner", response.Data.Owner)
+	d.Set("updated_time", response.Data.LastUpdateTime)
+	d.Set("updated_by", response.Data.LastUpdateUser)
+
+	log.Printf("[INFO] Updated Policy with guid %s\n", response.Data.PolicyID)
+	return nil
+}
+
+func resourceLaceworkPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	log.Printf("[INFO] Deleting Policy with guid %s\n", d.Id())
+	_, err := lacework.V2.Policy.Delete(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Deleted Policy with guid %s\n", d.Id())
+	return nil
+}
+
+func importLaceworkPolicy(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	lacework := meta.(*api.Client)
+
+	log.Printf("[INFO] Importing Lacework Policy with guid: %s\n", d.Id())
+
+	response, err := lacework.V2.Policy.Get(d.Id())
+	if err != nil {
+		return nil, fmt.Errorf(
+			"unable to import Lacework resource. Policy with guid '%s' was not found",
+			d.Id(),
+		)
+	}
+	log.Printf("[INFO] Policy found with guid: %s\n", response.Data.PolicyID)
+	return []*schema.ResourceData{d}, nil
+}

--- a/lacework/schema_validators.go
+++ b/lacework/schema_validators.go
@@ -1,0 +1,24 @@
+package lacework
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func ValidSeverity() schema.SchemaValidateDiagFunc {
+	return validation.ToDiagFunc(func(value interface{}, key string) ([]string, []error) {
+		switch strings.ToLower(value.(string)) {
+		case "critical", "high", "medium", "low", "info":
+			return nil, nil
+		default:
+			return nil, []error{
+				fmt.Errorf(
+					"%s: can only be 'Critical', 'High', 'Medium', 'Low', 'Info'", key,
+				),
+			}
+		}
+	})
+}

--- a/website/docs/r/policy.html.markdown
+++ b/website/docs/r/policy.html.markdown
@@ -1,0 +1,72 @@
+---
+subcategory: "Policy"
+layout: "lacework"
+page_title: "Lacework: lacework_policy"
+description: |-
+  Create and manage Policies
+---
+
+# lacework\_policy
+
+Lacework provides a highly scalable platform for creating, customizing, and managing custom policies
+against any datasource that is exposed via the Lacework Query Language (LQL).
+
+For more information, see the [Policy Overview Documentation](https://docs.lacework.com/custom-policies-overview).
+
+## Example Usage
+
+```hcl
+  resource "lacework_policy" "example" {
+  title        = "My Policy"
+  query_id     = "LW_Global_AWS_CTA_CloudTrailChange"
+  severity     = "high"
+  type         = "Violation"
+  description  = "Policy Created via Terraform"
+  remediation  = "Please investigate"
+  evaluation   = "Hourly"
+  evaluator_id = "Cloudtrail"
+  enabled      = true
+
+  alerting {
+    enabled = false
+    profile = "LW_CloudTrail_Alerts"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `title` - (Required) The policy title.
+* `query_id` - (Required) The query id.
+* `severity` - (Required) The list of the severities. Valid severities include:
+  `Critical`, `High`, `Medium`, `Low` and `Info`.
+* `type` - (Required) The policy type must be either `Violation` or `Summary`.
+* `description` - (Required) The description of the policy.
+* `evaluation` - (Required) Set the evaluation frequency `Hourly` or `Daily`.
+* `evaluator_id` - (Optional) The evaluator id. `Cloudtrail` must be set for all CloudTrail queries.
+* `remediation` - (Optional) The remediation message to display.
+* `limit` - (Optional) Set the maximum number of records returned by the policy. Maximum value is `1000`.
+* `enabled` - (Optional) Whether the policy is enabled or disabled.
+* `policy_id_suffix` - (Optional) The string appended to the end of the policy id.
+* `alerting` - (Optional) Alerting. See [Alerting](#alerting) below for details.
+
+### Alerting
+
+`alerting` supports the following arguments:
+
+* `profile` - (Required) The alerting profile.
+* `enabled` - (Optional) Whether the alerting profile is enabled or disabled.
+
+## Import
+
+A Lacework policy can be imported using a `POLICY_ID`, e.g.
+
+```
+$ terraform import lacework_policy.example MyLQLPolicyID
+```
+
+-> **Note:** To retreive the `POLICY_ID` from existing policies in your account, use the
+Lacework CLI command `lacework policy list`. To install this tool follow
+[this documentation](https://docs.lacework.com/cli/).

--- a/website/lacework.erb
+++ b/website/lacework.erb
@@ -254,6 +254,20 @@
         </li>
 
         <li>
+          <a href="#">LQL</a>
+          <ul class="nav">
+            <li>
+              <a href="#">Resources</a>
+              <ul class="nav nav-auto-expand">
+                <li>
+                  <a href="/docs/providers/lacework/r/policy.html">lacework_policy</a>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+
+        <li>
         <a href="#">Other Resources</a>
         <ul class="nav">
           <li>


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-provider-lacework/blob/main/CONTRIBUTING.md
--->

***Issue***: https://lacework.atlassian.net/browse/ALLY-871

***Description:***
Add new resource `lacework_policy`

Usage: 

```hcl
  resource "lacework_policy" "example" {
  title        = "My Policy"
  query_id     = "LW_Global_AWS_CTA_CloudTrailChange"
  severity     = "High"
  type         = "Violation"
  description  = "Policy Created via Terraform"
  remediation  = "Please investigate"
  evaluation   = "Hourly"
  evaluator_id = "Cloudtrail"
  enabled      = true

  alerting {
    enabled = false
    profile = "LW_CloudTrail_Alerts"
  }
}
```
