### PR TITLE
fix: prevent updating evaluator_id on existing queries

### DIFF
--- a/lacework/resource_lacework_query.go
+++ b/lacework/resource_lacework_query.go
@@ -117,6 +117,11 @@ func resourceLaceworkQueryUpdate(d *schema.ResourceData, meta interface{}) error
 		return errors.New("unable to change ID of an existing query")
 	}
 
+	// evaluator id cannot be updated
+	if d.HasChange("evaluator_id") && d.Get("evaluator_id").(string) != "<<IMPLICIT>>" {
+		return errors.New("unable to change the evaluator_id of an existing query")
+	}
+
 	query := api.UpdateQuery{
 		QueryText: d.Get("query").(string),
 	}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-provider-lacework/blob/main/CONTRIBUTING.md
--->

***Issue***: Include link to the Jira/Github Issue

***Description:***
Evaluator ID cannot be updated on an existing query
Add check to query update function to check for changes

***Additional Info:***
Include any other relevant information such as how to use the new functionality, screenshots, etc.