### PR TITLE
refactor: remove evaluator_id from policy and query resources

### DIFF
--- a/examples/resource_lacework_policy/main.tf
+++ b/examples/resource_lacework_policy/main.tf
@@ -14,7 +14,6 @@ resource "lacework_policy" "example" {
   description      = var.description
   remediation      = var.remediation
   evaluation       = var.evaluation
-  evaluator_id     = "Cloudtrail"
   enabled          = true
   policy_id_suffix = var.policy_id_suffix
 

--- a/examples/resource_lacework_query/main.tf
+++ b/examples/resource_lacework_query/main.tf
@@ -7,9 +7,8 @@ terraform {
 }
 
 resource "lacework_query" "example" {
-  query_id     = var.query_id
-  evaluator_id = var.eval_id
-  query        = var.query
+  query_id = var.query_id
+  query    = var.query
 }
 
 variable "query_id" {
@@ -17,23 +16,24 @@ variable "query_id" {
   default = "Lql_Terraform_Query"
 }
 
-variable "eval_id" {
-  type    = string
-  default = "Cloudtrail"
-}
-
 variable "query" {
   type    = string
   default = <<EOT
-    Lql_Terraform_Query {
-      source {CloudTrailRawEvents}
-      filter {EVENT_SOURCE = 'signin.amazonaws.com'
-      and EVENT:userIdentity."type"::String = 'AWSService'
-      and EVENT:sourceIPAddress not in ('1.1.1.1', '2.2.2.2')
-      and ERROR_CODE is null}
-    return distinct {INSERT_ID, INSERT_TIME, EVENT_TIME, EVENT}
-    }
-   EOT
+  Lql_Terraform_Query {
+      source {
+          CloudTrailRawEvents
+      }
+      filter {
+          EVENT_SOURCE = 'signin.amazonaws.com'
+          and EVENT:userIdentity."type"::String = 'AWSService'
+          and EVENT:sourceIPAddress not in ('1.1.1.1', '2.2.2.2')
+          and ERROR_CODE is null
+      }
+      return distinct {
+          INSERT_ID, INSERT_TIME, EVENT_TIME, EVENT
+      }
+  }
+EOT
 }
 
 output "query_id" {

--- a/integration/resource_lacework_query_test.go
+++ b/integration/resource_lacework_query_test.go
@@ -13,12 +13,11 @@ import (
 // It uses the go-sdk to verify the created query,
 // applies an update and destroys it
 //nolint
-func TestQueryCreate(t *testing.T) {
+func TestQueryCreateCloudtrail(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_query",
 		Vars: map[string]interface{}{
 			"query_id": "Lql_Terraform_Query",
-			"eval_id":  "Cloudtrail",
 			"query":    queryString},
 	})
 	defer terraform.Destroy(t, terraformOptions)
@@ -39,7 +38,6 @@ func TestQueryCreate(t *testing.T) {
 	// Update Query
 	terraformOptions.Vars = map[string]interface{}{
 		"query_id": "Lql_Terraform_Query",
-		"eval_id":  "Cloudtrail",
 		"query":    updatedQueryString,
 	}
 
@@ -58,7 +56,6 @@ func TestQueryCreate(t *testing.T) {
 	// Attempt to update query_id should return error
 	terraformOptions.Vars = map[string]interface{}{
 		"query_id": "Lql_Terraform_Query_Changed",
-		"eval_id":  "Cloudtrail",
 		"query":    updatedQueryString,
 	}
 
@@ -68,12 +65,11 @@ func TestQueryCreate(t *testing.T) {
 	assert.Contains(t, msg, "unable to change ID of an existing query")
 }
 
-func TestQueryCreateWithEmptyEvaluatorID(t *testing.T) {
+func TestQueryCreate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_query",
 		Vars: map[string]interface{}{
 			"query_id": "Lql_Terraform_Query",
-			"eval_id":  "",
 			"query":    queryStringK8},
 	})
 	defer terraform.Destroy(t, terraformOptions)
@@ -94,7 +90,6 @@ func TestQueryCreateWithEmptyEvaluatorID(t *testing.T) {
 	// Update Query
 	terraformOptions.Vars = map[string]interface{}{
 		"query_id": "Lql_Terraform_Query",
-		"eval_id":  "",
 		"query":    queryStringK8,
 	}
 

--- a/lacework/resource_lacework_policy.go
+++ b/lacework/resource_lacework_policy.go
@@ -88,12 +88,6 @@ func resourceLaceworkPolicy() *schema.Resource {
 				Optional:    true,
 				Description: "The string appended to the end of the policy id",
 			},
-			"evaluator_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "",
-				Description: "The policy evaluator id.",
-			},
 			"limit": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -159,7 +153,6 @@ func resourceLaceworkPolicyCreate(d *schema.ResourceData, meta interface{}) erro
 	)
 
 	policy := api.NewPolicy{
-		EvaluatorID:   d.Get("evaluator_id").(string),
 		PolicyType:    d.Get("type").(string),
 		QueryID:       d.Get("query_id").(string),
 		Title:         d.Get("title").(string),
@@ -203,7 +196,6 @@ func resourceLaceworkPolicyRead(d *schema.ResourceData, meta interface{}) error 
 	d.SetId(response.Data.PolicyID)
 	d.Set("title", response.Data.Title)
 	d.Set("query_id", response.Data.QueryID)
-	d.Set("evaluator_id", response.Data.EvaluatorID)
 	d.Set("enabled", response.Data.Enabled)
 	d.Set("description", response.Data.Description)
 	d.Set("evaluation", response.Data.EvalFrequency)
@@ -238,7 +230,6 @@ func resourceLaceworkPolicyUpdate(d *schema.ResourceData, meta interface{}) erro
 	policyLimit := d.Get("limit").(int)
 
 	policy := api.UpdatePolicy{
-		EvaluatorID:   d.Get("evaluator_id").(string),
 		PolicyType:    d.Get("type").(string),
 		QueryID:       d.Get("query_id").(string),
 		Title:         d.Get("title").(string),

--- a/lacework/resource_lacework_query.go
+++ b/lacework/resource_lacework_query.go
@@ -31,14 +31,6 @@ func resourceLaceworkQuery() *schema.Resource {
 				Required:    true,
 				Description: "The query string",
 			},
-			"evaluator_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "The query evaluator id",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return old == "<<IMPLICIT>>" || new == "<<IMPLICIT>>"
-				},
-			},
 			"updated_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -65,9 +57,8 @@ func resourceLaceworkQueryCreate(d *schema.ResourceData, meta interface{}) error
 	)
 
 	query := api.NewQuery{
-		QueryID:     d.Get("query_id").(string),
-		QueryText:   d.Get("query").(string),
-		EvaluatorID: d.Get("evaluator_id").(string),
+		QueryID:   d.Get("query_id").(string),
+		QueryText: d.Get("query").(string),
 	}
 
 	log.Printf("[INFO] Creating Query with data:\n%+v\n", query)
@@ -99,7 +90,6 @@ func resourceLaceworkQueryRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("query", response.Data.QueryText)
 	d.Set("owner", response.Data.Owner)
-	d.Set("evaluator_id", response.Data.EvaluatorID)
 	d.Set("updated_time", response.Data.LastUpdateTime)
 	d.Set("updated_by", response.Data.LastUpdateUser)
 	d.Set("result_schema", response.Data.ResultSchema)
@@ -115,11 +105,6 @@ func resourceLaceworkQueryUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if d.HasChange("query_id") {
 		return errors.New("unable to change ID of an existing query")
-	}
-
-	// evaluator id cannot be updated
-	if d.HasChange("evaluator_id") && d.Get("evaluator_id").(string) != "<<IMPLICIT>>" {
-		return errors.New("unable to change the evaluator_id of an existing query")
 	}
 
 	query := api.UpdateQuery{


### PR DESCRIPTION
***Issue***: N/A

***Description:***
We are about to release the deprecation of the field `evaluatorId` from our APIs, see https://lacework.atlassian.net/browse/RAIN-27035

This change is refactoring both, query and policy resources, to remove this `evaluator_id` field. 

***Additional Info:***
We may need to update more tests. Also, I want to include a change that removes the need for
the user to enter the query id twice. For that, I need to ask around a bit more about the future
of this field from an API standpoint.

## NOTE: This change will fail until we deploy 4.6
