### PR TITLE
refactor(lacework_query): remove query_id from Schema

### DIFF
--- a/examples/resource_lacework_query/main.tf
+++ b/examples/resource_lacework_query/main.tf
@@ -7,13 +7,7 @@ terraform {
 }
 
 resource "lacework_query" "example" {
-  query_id = var.query_id
-  query    = var.query
-}
-
-variable "query_id" {
-  type    = string
-  default = "Lql_Terraform_Query"
+  query = var.query
 }
 
 variable "query" {

--- a/lacework/resource_lacework_query_test.go
+++ b/lacework/resource_lacework_query_test.go
@@ -1,0 +1,150 @@
+package lacework
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetIDFromLQLQuery(t *testing.T) {
+	cases := []struct {
+		Query           string
+		expectedQueryID string
+		expectedError   string
+	}{
+		{Query: "MyLQLQuery                   {}",
+			expectedQueryID: "MyLQLQuery"},
+		{Query: "foo123{source {bar} return distinct {xyz}}",
+			expectedQueryID: "foo123"},
+		{Query: `
+
+     ASuper_Long_ID_madeUP_with_Numbers_1234
+
+{
+source {bar}
+filter {abc}
+return distinct {xyz}
+}`,
+			expectedQueryID: "ASuper_Long_ID_madeUP_with_Numbers_1234"},
+		{Query: `Lql_Terraform_Query{
+    source {
+        CloudTrailRawEvents
+    }
+    filter {
+        EVENT_SOURCE = 'signin.amazonaws.com'
+        and EVENT_NAME in ('ConsoleLogin')
+        and EVENT:additionalEventData.MFAUsed::String = 'No'
+        and EVENT:responseElements.ConsoleLogin::String = 'Success'
+        and ERROR_CODE is null
+    }
+    return distinct {
+        INSERT_ID,
+        INSERT_TIME,
+        EVENT_TIME,
+        EVENT
+    }
+}`,
+			expectedQueryID: "Lql_Terraform_Query"},
+
+		// Errors!!!!
+		{Query: "",
+			expectedError: `query id not found. (malformed)
+
+> Your query:
+
+
+> Compare provided query to the example at:
+
+    https://docs.lacework.com/lql-overview
+`},
+		{Query: "{}",
+			expectedError: `query id not found. (malformed)
+
+> Your query:
+{}
+
+> Compare provided query to the example at:
+
+    https://docs.lacework.com/lql-overview
+`},
+		{Query: "     {}",
+			expectedError: `query id not found. (malformed)
+
+> Your query:
+     {}
+
+> Compare provided query to the example at:
+
+    https://docs.lacework.com/lql-overview
+`},
+		{Query: `MyQueryWrongFormat }`,
+			expectedError: `query id not found. (malformed)
+
+> Your query:
+MyQueryWrongFormat }
+
+> Compare provided query to the example at:
+
+    https://docs.lacework.com/lql-overview
+`},
+		{Query: `MyQueryWrongFormat } 
+{
+    source {
+        CloudTrailRawEvents
+    }
+    filter {
+        EVENT_SOURCE = 'signin.amazonaws.com'
+        and EVENT_NAME in ('ConsoleLogin')
+        and EVENT:additionalEventData.MFAUsed::String = 'No'
+        and EVENT:responseElements.ConsoleLogin::String = 'Success'
+        and ERROR_CODE is null
+    }
+    return distinct {
+        INSERT_ID,
+        INSERT_TIME,
+        EVENT_TIME,
+        EVENT
+    }
+}`,
+			expectedError: `query id not found. (malformed)
+
+> Your query:
+MyQueryWrongFormat } 
+{
+    source {
+        CloudTrailRawEvents
+    }
+    filter {
+        EVENT_SOURCE = 'signin.amazonaws.com'
+        and EVENT_NAME in ('ConsoleLogin')
+        and EVENT:additionalEventData.MFAUsed::String = 'No'
+        and EVENT:responseElements.ConsoleLogin::String = 'Success'
+        and ERROR_CODE is null
+    }
+    return distinct {
+        INSERT_ID,
+        INSERT_TIME,
+        EVENT_TIME,
+        EVENT
+    }
+}
+
+> Compare provided query to the example at:
+
+    https://docs.lacework.com/lql-overview
+`},
+	}
+
+	for i, kase := range cases {
+		t.Run(fmt.Sprintf("test case %d", i), func(t *testing.T) {
+			actualID, err := getIDFromLQLQuery(kase.Query)
+			if kase.expectedError != "" {
+				if assert.Error(t, err, "should have failed") {
+					assert.Equal(t, kase.expectedError, err.Error())
+				}
+			}
+			assert.Equal(t, kase.expectedQueryID, actualID)
+		})
+	}
+}

--- a/website/docs/r/query.html.markdown
+++ b/website/docs/r/query.html.markdown
@@ -20,7 +20,6 @@ Query all EC2 instances with public IP addresses.
 
 ```hcl
 resource "lacework_query" "example" {
-  query_id = "TF_AWS_Config_EC2InstanceWithPublicIPAddress"
   query    = <<EOT
   TF_AWS_Config_EC2InstanceWithPublicIPAddress {
       source {
@@ -48,7 +47,6 @@ Query CloutTrail events and filter only S3 buckets with ACL 'public-read', 'publ
 
 ```hcl
 resource "lacework_query" "example" {
-  query_id       = "TF_AWS_CTA_S3PublicACLCreated"
   query          = <<EOT
   TF_AWS_CTA_S3PublicACLCreated {
       source {
@@ -77,7 +75,6 @@ EOT
 
 The following arguments are supported:
 
-* `query_id` - (Required) The query id.
 * `query` - (Required) The query string.
 
 ## Import


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-provider-lacework/blob/main/CONTRIBUTING.md
--->

***Issue***: N/A

***Description:***
The motivation of this change it to avoid making our users set the query
id twice, it makes no sense to allow them to configure a different query
id, especially not since the platform enforces both, the query id and the
query text to match the same id.

We are removing the `query_id` field from the Schema of the
`lacework_query` resource and instead, we are automatically guessing the
query id from the actual query.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

***Additional Info:***
Added a number of unit tests and updated both, integration tests and documentation.