### PR TITLE
refactor: encourage the use of anonymous queries

### DIFF
--- a/examples/resource_lacework_query/main.tf
+++ b/examples/resource_lacework_query/main.tf
@@ -19,7 +19,7 @@ variable "query_id" {
 variable "query" {
   type    = string
   default = <<EOT
-  Lql_Terraform_Query {
+  {
       source {
           CloudTrailRawEvents
       }

--- a/website/docs/r/policy.html.markdown
+++ b/website/docs/r/policy.html.markdown
@@ -21,7 +21,7 @@ Create a Lacework Policy to check for a change of password from an RDS cluster.
 resource "lacework_query" "AWS_CTA_AuroraPasswordChange" {
   query_id = "TF_AWS_CTA_AuroraPasswordChange"
   query    = <<EOT
-  TF_AWS_CTA_AuroraPasswordChange {
+  {
       source {
           CloudTrailRawEvents
       }

--- a/website/docs/r/query.html.markdown
+++ b/website/docs/r/query.html.markdown
@@ -22,7 +22,7 @@ Query all EC2 instances with public IP addresses.
 resource "lacework_query" "example" {
   query_id = "TF_AWS_Config_EC2InstanceWithPublicIPAddress"
   query    = <<EOT
-  TF_AWS_Config_EC2InstanceWithPublicIPAddress {
+  {
       source {
           LW_CFG_AWS_EC2_INSTANCES
       }
@@ -50,7 +50,7 @@ Query CloutTrail events and filter only S3 buckets with ACL 'public-read', 'publ
 resource "lacework_query" "example" {
   query_id       = "TF_AWS_CTA_S3PublicACLCreated"
   query          = <<EOT
-  TF_AWS_CTA_S3PublicACLCreated {
+  {
       source {
           CloudTrailRawEvents
       }


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-provider-lacework/blob/main/CONTRIBUTING.md
--->

***Issue***: N/A

***Description:***
The motivation of this change it to avoid making our users set the query
id twice, it makes no sense to allow them to configure a different query
id, especially not since the platform enforces that both, the query id and
the query text match.

Furthermore, we have introduced the concept of anonymous queries, such
queries are encouraged and should the default way that users create and
manage LQL queries.

This change updates all documentation and tests to avoid adding the
query id inside the query text.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

***Additional Info:***
Updated integration tests and documentation.