### PR TITLE
feat: add validation to ecr 'limit_num_imgs'

### DIFF
--- a/examples/resource_lacework_integration_ecr/iam_role/main.tf
+++ b/examples/resource_lacework_integration_ecr/iam_role/main.tf
@@ -16,4 +16,5 @@ resource "lacework_integration_ecr" "iam_role" {
     external_id = var.external_id
   }
   non_os_package_support = var.non_os_package_support
+  limit_num_imgs         = var.num_images
 }

--- a/examples/resource_lacework_integration_ecr/iam_role/variables.tf
+++ b/examples/resource_lacework_integration_ecr/iam_role/variables.tf
@@ -20,4 +20,8 @@ variable "non_os_package_support" {
   type      = bool
   default   = true
 }
+variable "num_images" {
+  type      = number
+  default   = 10
+}
 

--- a/integration/resource_lacework_query_test.go
+++ b/integration/resource_lacework_query_test.go
@@ -1,7 +1,9 @@
 package integration
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
@@ -14,10 +16,11 @@ import (
 // applies an update and destroys it
 //nolint
 func TestQueryCreateCloudtrail(t *testing.T) {
+	queryID := fmt.Sprintf("Lql_Terraform_Query_%d", time.Now().UnixMilli())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_query",
 		Vars: map[string]interface{}{
-			"query_id": "Lql_Terraform_Query",
+			"query_id": queryID,
 			"query":    queryString},
 	})
 	defer terraform.Destroy(t, terraformOptions)
@@ -29,15 +32,15 @@ func TestQueryCreateCloudtrail(t *testing.T) {
 	actualQueryID := terraform.Output(t, terraformOptions, "query_id")
 	actualQuery := terraform.Output(t, terraformOptions, "query")
 
-	assert.Equal(t, "Lql_Terraform_Query", createProps.Data.QueryID)
+	assert.Equal(t, queryID, createProps.Data.QueryID)
 	assert.Equal(t, queryString, createProps.Data.QueryText)
 
-	assert.Equal(t, "Lql_Terraform_Query", actualQueryID)
+	assert.Equal(t, queryID, actualQueryID)
 	assert.Equal(t, queryString, actualQuery)
 
 	// Update Query
 	terraformOptions.Vars = map[string]interface{}{
-		"query_id": "Lql_Terraform_Query",
+		"query_id": queryID,
 		"query":    updatedQueryString,
 	}
 
@@ -47,10 +50,10 @@ func TestQueryCreateCloudtrail(t *testing.T) {
 	actualQueryID = terraform.Output(t, terraformOptions, "query_id")
 	actualQuery = terraform.Output(t, terraformOptions, "query")
 
-	assert.Equal(t, "Lql_Terraform_Query", updateProps.Data.QueryID)
+	assert.Equal(t, queryID, updateProps.Data.QueryID)
 	assert.Equal(t, updatedQueryString, updateProps.Data.QueryText)
 
-	assert.Equal(t, "Lql_Terraform_Query", actualQueryID)
+	assert.Equal(t, queryID, actualQueryID)
 	assert.Equal(t, updatedQueryString, actualQuery)
 
 	// Attempt to update query_id should return error
@@ -66,10 +69,11 @@ func TestQueryCreateCloudtrail(t *testing.T) {
 }
 
 func TestQueryCreate(t *testing.T) {
+	queryID := fmt.Sprintf("Lql_Terraform_Query_%d", time.Now().UnixMilli())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_query",
 		Vars: map[string]interface{}{
-			"query_id": "Lql_Terraform_Query",
+			"query_id": queryID,
 			"query":    queryStringK8},
 	})
 	defer terraform.Destroy(t, terraformOptions)
@@ -81,15 +85,15 @@ func TestQueryCreate(t *testing.T) {
 	actualQueryID := terraform.Output(t, terraformOptions, "query_id")
 	actualQuery := terraform.Output(t, terraformOptions, "query")
 
-	assert.Equal(t, "Lql_Terraform_Query", createProps.Data.QueryID)
+	assert.Equal(t, queryID, createProps.Data.QueryID)
 	assert.Equal(t, queryStringK8, createProps.Data.QueryText)
 
-	assert.Equal(t, "Lql_Terraform_Query", actualQueryID)
+	assert.Equal(t, queryID, actualQueryID)
 	assert.Equal(t, queryStringK8, actualQuery)
 
 	// Update Query
 	terraformOptions.Vars = map[string]interface{}{
-		"query_id": "Lql_Terraform_Query",
+		"query_id": queryID,
 		"query":    queryStringK8,
 	}
 
@@ -99,10 +103,10 @@ func TestQueryCreate(t *testing.T) {
 	actualQueryID = terraform.Output(t, terraformOptions, "query_id")
 	actualQuery = terraform.Output(t, terraformOptions, "query")
 
-	assert.Equal(t, "Lql_Terraform_Query", updateProps.Data.QueryID)
+	assert.Equal(t, queryID, updateProps.Data.QueryID)
 	assert.Equal(t, queryStringK8, updateProps.Data.QueryText)
 
-	assert.Equal(t, "Lql_Terraform_Query", actualQueryID)
+	assert.Equal(t, queryID, actualQueryID)
 	assert.Equal(t, queryStringK8, actualQuery)
 
 	// Run apply again
@@ -113,10 +117,10 @@ func TestQueryCreate(t *testing.T) {
 	actualQueryID = terraform.Output(t, terraformOptions, "query_id")
 	actualQuery = terraform.Output(t, terraformOptions, "query")
 
-	assert.Equal(t, "Lql_Terraform_Query", thirdApplyProps.Data.QueryID)
+	assert.Equal(t, queryID, thirdApplyProps.Data.QueryID)
 	assert.Equal(t, queryStringK8, thirdApplyProps.Data.QueryText)
 
-	assert.Equal(t, "Lql_Terraform_Query", actualQueryID)
+	assert.Equal(t, queryID, actualQueryID)
 	assert.Equal(t, queryStringK8, actualQuery)
 }
 

--- a/lacework/resource_lacework_integration_ecr.go
+++ b/lacework/resource_lacework_integration_ecr.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/pkg/errors"
 
 	"github.com/lacework/go-sdk/api"
@@ -177,10 +178,11 @@ func resourceLaceworkIntegrationEcr() *schema.Resource {
 				ConflictsWith: []string{"limit_by_repos"},
 			},
 			"limit_num_imgs": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Default:     5,
-				Description: "The maximum number of newest container images to assess per repository",
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      5,
+				ValidateFunc: validation.IntInSlice([]int{5, 10, 15}),
+				Description:  "The maximum number of newest container images to assess per repository",
 			},
 			"aws_auth_type": {
 				Type:        schema.TypeString,


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-provider-lacework/blob/main/CONTRIBUTING.md
--->

***Issue***: https://github.com/lacework/terraform-provider-lacework/issues/270
https://lacework.atlassian.net/browse/ALLY-889

***Description:***
Add validation to ecr 'limit_num_imgs', which can only be 5, 10 ,15

***Additional Info:***
Added test `TestIntegrationECRNumImagesValidation` 