### PR TITLE
fix: migrate agent access token data source to use v2 api

### DIFF
--- a/examples/data_source_lacework_agent_access_token/main.tf
+++ b/examples/data_source_lacework_agent_access_token/main.tf
@@ -6,14 +6,20 @@ terraform {
   }
 }
 
-provider "lacework" {
-}
-
 data "lacework_agent_access_token" "k8s" {
-  name = "k8s-deployments"
+  name = var.token_name
 }
 
 output "lacework_agent_access_token" {
   value     = data.lacework_agent_access_token.k8s.token
   sensitive = true
+}
+
+output "token_name" {
+  value = data.lacework_agent_access_token.k8s.name
+}
+
+variable "token_name" {
+  type    = string
+  default = "k8s-deployments"
 }

--- a/examples/data_source_lacework_agent_access_token/main.tf
+++ b/examples/data_source_lacework_agent_access_token/main.tf
@@ -1,4 +1,13 @@
-provider "lacework" {}
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+provider "lacework" {
+}
 
 data "lacework_agent_access_token" "k8s" {
   name = "k8s-deployments"

--- a/examples/resource_lacework_agent_access_token/main.tf
+++ b/examples/resource_lacework_agent_access_token/main.tf
@@ -1,6 +1,15 @@
 provider "lacework" {}
 
 resource "lacework_agent_access_token" "k8s" {
-  name        = "k8s-deployments"
+  name        = var.token_name
   description = "Token for K8S clusters"
+}
+
+variable "token_name" {
+  type    = string
+  default = "k8s-deployments"
+}
+
+output "token_name" {
+  value = lacework_agent_access_token.k8s.name
 }

--- a/examples/resource_lacework_agent_access_token/main.tf
+++ b/examples/resource_lacework_agent_access_token/main.tf
@@ -1,4 +1,10 @@
-provider "lacework" {}
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
 
 resource "lacework_agent_access_token" "k8s" {
   name        = var.token_name

--- a/integration/resource_lacework_agent_access_token_test.go
+++ b/integration/resource_lacework_agent_access_token_test.go
@@ -1,0 +1,42 @@
+package integration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAgentAccessTokenCreate apply terraform:
+// => '../examples/lacework_agent_access_token'
+//
+// It uses the go-sdk to verify the created token and destroys it
+func TestAgentAccessTokenCreate(t *testing.T) {
+	tokenName := fmt.Sprintf("Agent Token Terraform - %s", time.Now())
+	// Create new Agent Access Token
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/resource_lacework_alert_channel_aws_s3",
+		Vars: map[string]interface{}{
+			"token_name": tokenName,
+		},
+	})
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+	createName := terraform.Output(t, terraformOptions, "token_name")
+	assert.Equal(t, tokenName, createName)
+
+	// Read Agent Access Token
+	dataTerraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/data_source_lacework_agent_access_token",
+		Vars: map[string]interface{}{
+			"token_name": tokenName,
+		}})
+	defer terraform.Destroy(t, dataTerraformOptions)
+
+	terraform.InitAndApplyAndIdempotent(t, dataTerraformOptions)
+	dataName := terraform.Output(t, terraformOptions, "token_name")
+	assert.Equal(t, tokenName, dataName)
+}

--- a/integration/resource_lacework_agent_access_token_test.go
+++ b/integration/resource_lacework_agent_access_token_test.go
@@ -17,7 +17,7 @@ func TestAgentAccessTokenCreate(t *testing.T) {
 	tokenName := fmt.Sprintf("Agent Token Terraform - %s", time.Now())
 	// Create new Agent Access Token
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		TerraformDir: "../examples/resource_lacework_alert_channel_aws_s3",
+		TerraformDir: "../examples/resource_lacework_agent_access_token",
 		Vars: map[string]interface{}{
 			"token_name": tokenName,
 		},

--- a/lacework/data_source_lacework_agent_access_token.go
+++ b/lacework/data_source_lacework_agent_access_token.go
@@ -30,7 +30,7 @@ func dataSourceLaceworkAgentAccessTokenRead(d *schema.ResourceData, meta interfa
 	lacework := meta.(*api.Client)
 
 	log.Printf("[INFO] Lookup agent access token.")
-	response, err := lacework.Agents.ListTokens()
+	response, err := lacework.V2.AgentAccessTokens.List()
 	if err != nil {
 		return err
 	}
@@ -39,7 +39,7 @@ func dataSourceLaceworkAgentAccessTokenRead(d *schema.ResourceData, meta interfa
 	for _, token := range response.Data {
 		if token.TokenAlias == lookupName {
 			log.Printf("[INFO] agent access token found. name=%s, description=%s, enabled=%t",
-				token.TokenAlias, token.Props.Description, token.Status())
+				token.TokenAlias, token.Props.Description, token.State())
 
 			d.Set("token", token.AccessToken)
 			d.SetId(token.TokenAlias)


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-provider-lacework/blob/main/CONTRIBUTING.md
--->

***Issue***:  https://lacework.atlassian.net/browse/ALLY-921

***Description:***
dataSourceLaceworkAgentAccessTokenRead retrieved tokens using `v1/external/tokens` change this request to use `v2/AgentAccessTokens`

***Additional Info:***
Include any other relevant information such as how to use the new functionality, screenshots, etc.