### PR TITLE
docs: update report_rule.html.markdown

### DIFF
--- a/website/docs/r/report_rule.html.markdown
+++ b/website/docs/r/report_rule.html.markdown
@@ -35,7 +35,7 @@ resource "lacework_report_rule" "example" {
 
 #### Report Rule with Gcp Compliance Reports and Gcp Resource Group
 ```hcl
-resource "lacework_report_channel_email" "team_email" {
+resource "lacework_alert_channel_email" "team_email" {
   name       = "Team Emails"
   recipients = ["foo@example.com", "bar@example.com"]
 }


### PR DESCRIPTION
fixed a typo - i believe it's meant to be `lacework_alert_channel_email` rather than `lacework_report_channel_email` since that resource type does not exist.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-provider-lacework/blob/main/CONTRIBUTING.md
--->

***Issue***: Include link to the Jira/Github Issue

***Description:***
Provide a detailed description of the changes made by this pull request.

***Additional Info:***
Include any other relevant information such as how to use the new functionality, screenshots, etc.