### PR TITLE
fix: handle resource deleted outside of terraform

### DIFF
--- a/lacework/errors.go
+++ b/lacework/errors.go
@@ -13,9 +13,9 @@ func notFound(err error) bool {
 	return errors.As(err, &e)
 }
 
-func resourceNotFound(d *schema.ResourceData, err error, id string) error {
+func resourceNotFound(d *schema.ResourceData, err error) error {
 	if notFound(err) && !d.IsNewResource() {
-		log.Printf("[WARN] resource with guid: %s\n not found, removing from state", id)
+		log.Printf("[WARN] resource with guid: %s\n not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}

--- a/lacework/errors.go
+++ b/lacework/errors.go
@@ -1,0 +1,23 @@
+package lacework
+
+import (
+	"errors"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func notFound(err error) bool {
+	var e *resource.NotFoundError
+	return errors.As(err, &e)
+}
+
+func resourceNotFound(d *schema.ResourceData, err error, id string) error {
+	if notFound(err) && !d.IsNewResource() {
+		log.Printf("[WARN] resource with guid: %s\n not found, removing from state", id)
+		d.SetId("")
+		return nil
+	}
+	return err
+}

--- a/lacework/resource_lacework_agent_access_token.go
+++ b/lacework/resource_lacework_agent_access_token.go
@@ -113,7 +113,7 @@ func resourceLaceworkAgentAccessTokenRead(d *schema.ResourceData, meta interface
 	log.Printf("[INFO] Reading agent access token.")
 	response, err := lacework.Agents.GetToken(d.Get("token").(string))
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	for _, token := range response.Data {

--- a/lacework/resource_lacework_agent_access_token.go
+++ b/lacework/resource_lacework_agent_access_token.go
@@ -113,7 +113,7 @@ func resourceLaceworkAgentAccessTokenRead(d *schema.ResourceData, meta interface
 	log.Printf("[INFO] Reading agent access token.")
 	response, err := lacework.Agents.GetToken(d.Get("token").(string))
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	for _, token := range response.Data {

--- a/lacework/resource_lacework_alert_channel_aws_cloudwatch.go
+++ b/lacework/resource_lacework_alert_channel_aws_cloudwatch.go
@@ -135,7 +135,7 @@ func resourceLaceworkAlertChannelAwsCloudWatchRead(d *schema.ResourceData, meta 
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.CloudwatchEbAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetCloudwatchEb(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, response.Data.IntgGuid)
+		return resourceNotFound(d, err)
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_channel_aws_cloudwatch.go
+++ b/lacework/resource_lacework_alert_channel_aws_cloudwatch.go
@@ -135,7 +135,7 @@ func resourceLaceworkAlertChannelAwsCloudWatchRead(d *schema.ResourceData, meta 
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.CloudwatchEbAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetCloudwatchEb(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, response.Data.IntgGuid)
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_channel_aws_s3.go
+++ b/lacework/resource_lacework_alert_channel_aws_s3.go
@@ -137,7 +137,7 @@ func resourceLaceworkAlertChannelAwsS3Read(d *schema.ResourceData, meta interfac
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.AwsS3AlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetAwsS3(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_channel_aws_s3.go
+++ b/lacework/resource_lacework_alert_channel_aws_s3.go
@@ -137,7 +137,7 @@ func resourceLaceworkAlertChannelAwsS3Read(d *schema.ResourceData, meta interfac
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.AwsS3AlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetAwsS3(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_channel_cisco_webex.go
+++ b/lacework/resource_lacework_alert_channel_cisco_webex.go
@@ -114,7 +114,7 @@ func resourceLaceworkAlertChannelCiscoWebexRead(d *schema.ResourceData, meta int
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.CiscoSparkWebhookAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetCiscoSparkWebhook(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_channel_cisco_webex.go
+++ b/lacework/resource_lacework_alert_channel_cisco_webex.go
@@ -114,7 +114,7 @@ func resourceLaceworkAlertChannelCiscoWebexRead(d *schema.ResourceData, meta int
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.CiscoSparkWebhookAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetCiscoSparkWebhook(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_channel_datadog.go
+++ b/lacework/resource_lacework_alert_channel_datadog.go
@@ -159,7 +159,7 @@ func resourceLaceworkAlertChannelDatadogRead(d *schema.ResourceData, meta interf
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.DatadogAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetDatadog(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_channel_datadog.go
+++ b/lacework/resource_lacework_alert_channel_datadog.go
@@ -159,7 +159,7 @@ func resourceLaceworkAlertChannelDatadogRead(d *schema.ResourceData, meta interf
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.DatadogAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetDatadog(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_channel_email.go
+++ b/lacework/resource_lacework_alert_channel_email.go
@@ -123,7 +123,7 @@ func resourceLaceworkAlertChannelEmailRead(d *schema.ResourceData, meta interfac
 	log.Printf("[INFO] Reading %s integration with guid: %s\n", api.EmailUserAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetEmailUser(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_channel_email.go
+++ b/lacework/resource_lacework_alert_channel_email.go
@@ -123,7 +123,7 @@ func resourceLaceworkAlertChannelEmailRead(d *schema.ResourceData, meta interfac
 	log.Printf("[INFO] Reading %s integration with guid: %s\n", api.EmailUserAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetEmailUser(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_channel_gcp_pub_sub.go
+++ b/lacework/resource_lacework_alert_channel_gcp_pub_sub.go
@@ -196,7 +196,7 @@ func resourceLaceworkAlertChannelGcpPubSubRead(d *schema.ResourceData, meta inte
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.GcpPubSubAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetGcpPubSub(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.Set("name", response.Data.Name)
@@ -208,7 +208,7 @@ func resourceLaceworkAlertChannelGcpPubSubRead(d *schema.ResourceData, meta inte
 	d.Set("org_level", response.Data.IsOrg == 1)
 	d.Set("project_id", response.Data.Data.ProjectID)
 	d.Set("topic_id", response.Data.Data.TopicID)
-	d.Set("issue_grouoing", response.Data.Data.IssueGrouping)
+	d.Set("issue_grouping", response.Data.Data.IssueGrouping)
 
 	creds := make(map[string]string)
 	creds["client_id"] = response.Data.Data.Credentials.ClientID

--- a/lacework/resource_lacework_alert_channel_gcp_pub_sub.go
+++ b/lacework/resource_lacework_alert_channel_gcp_pub_sub.go
@@ -196,7 +196,7 @@ func resourceLaceworkAlertChannelGcpPubSubRead(d *schema.ResourceData, meta inte
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.GcpPubSubAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetGcpPubSub(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_channel_jira_cloud.go
+++ b/lacework/resource_lacework_alert_channel_jira_cloud.go
@@ -172,7 +172,7 @@ func resourceLaceworkAlertChannelJiraCloudRead(d *schema.ResourceData, meta inte
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.JiraAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetJira(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_channel_jira_cloud.go
+++ b/lacework/resource_lacework_alert_channel_jira_cloud.go
@@ -172,7 +172,7 @@ func resourceLaceworkAlertChannelJiraCloudRead(d *schema.ResourceData, meta inte
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.JiraAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetJira(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_channel_jira_server.go
+++ b/lacework/resource_lacework_alert_channel_jira_server.go
@@ -170,7 +170,7 @@ func resourceLaceworkAlertChannelJiraServerRead(d *schema.ResourceData, meta int
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.JiraAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetJira(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_channel_jira_server.go
+++ b/lacework/resource_lacework_alert_channel_jira_server.go
@@ -170,7 +170,7 @@ func resourceLaceworkAlertChannelJiraServerRead(d *schema.ResourceData, meta int
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.JiraAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetJira(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_channel_microsoft_teams.go
+++ b/lacework/resource_lacework_alert_channel_microsoft_teams.go
@@ -114,7 +114,7 @@ func resourceLaceworkAlertChannelMicrosoftTeamsRead(d *schema.ResourceData, meta
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.MicrosoftTeamsAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetMicrosoftTeams(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_channel_microsoft_teams.go
+++ b/lacework/resource_lacework_alert_channel_microsoft_teams.go
@@ -114,7 +114,7 @@ func resourceLaceworkAlertChannelMicrosoftTeamsRead(d *schema.ResourceData, meta
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.MicrosoftTeamsAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetMicrosoftTeams(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_channel_newrelic.go
+++ b/lacework/resource_lacework_alert_channel_newrelic.go
@@ -119,7 +119,7 @@ func resourceLaceworkAlertChannelNewRelicRead(d *schema.ResourceData, meta inter
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.NewRelicInsightsAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetNewRelicInsights(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	integration := response.Data

--- a/lacework/resource_lacework_alert_channel_newrelic.go
+++ b/lacework/resource_lacework_alert_channel_newrelic.go
@@ -119,7 +119,7 @@ func resourceLaceworkAlertChannelNewRelicRead(d *schema.ResourceData, meta inter
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.NewRelicInsightsAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetNewRelicInsights(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	integration := response.Data

--- a/lacework/resource_lacework_alert_channel_pagerduty.go
+++ b/lacework/resource_lacework_alert_channel_pagerduty.go
@@ -116,7 +116,7 @@ func resourceLaceworkAlertChannelPagerDutyRead(d *schema.ResourceData, meta inte
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.PagerDutyApiAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetPagerDutyApi(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	integration := response.Data

--- a/lacework/resource_lacework_alert_channel_pagerduty.go
+++ b/lacework/resource_lacework_alert_channel_pagerduty.go
@@ -116,7 +116,7 @@ func resourceLaceworkAlertChannelPagerDutyRead(d *schema.ResourceData, meta inte
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.PagerDutyApiAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetPagerDutyApi(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	integration := response.Data

--- a/lacework/resource_lacework_alert_channel_qradar.go
+++ b/lacework/resource_lacework_alert_channel_qradar.go
@@ -150,7 +150,7 @@ func resourceLaceworkAlertChannelQRadarRead(d *schema.ResourceData, meta interfa
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.IbmQRadarAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetIbmQRadar(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	integration := response.Data

--- a/lacework/resource_lacework_alert_channel_qradar.go
+++ b/lacework/resource_lacework_alert_channel_qradar.go
@@ -150,7 +150,7 @@ func resourceLaceworkAlertChannelQRadarRead(d *schema.ResourceData, meta interfa
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.IbmQRadarAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetIbmQRadar(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	integration := response.Data

--- a/lacework/resource_lacework_alert_channel_service_now.go
+++ b/lacework/resource_lacework_alert_channel_service_now.go
@@ -149,7 +149,7 @@ func resourceLaceworkAlertChannelServiceNowRead(d *schema.ResourceData, meta int
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.ServiceNowRestAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetServiceNowRest(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 	integration := response.Data
 	d.Set("name", integration.Name)

--- a/lacework/resource_lacework_alert_channel_service_now.go
+++ b/lacework/resource_lacework_alert_channel_service_now.go
@@ -149,7 +149,7 @@ func resourceLaceworkAlertChannelServiceNowRead(d *schema.ResourceData, meta int
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.ServiceNowRestAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetServiceNowRest(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 	integration := response.Data
 	d.Set("name", integration.Name)

--- a/lacework/resource_lacework_alert_channel_slack.go
+++ b/lacework/resource_lacework_alert_channel_slack.go
@@ -114,7 +114,7 @@ func resourceLaceworkAlertChannelSlackRead(d *schema.ResourceData, meta interfac
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.SlackChannelAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetSlackChannel(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_channel_slack.go
+++ b/lacework/resource_lacework_alert_channel_slack.go
@@ -114,7 +114,7 @@ func resourceLaceworkAlertChannelSlackRead(d *schema.ResourceData, meta interfac
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.SlackChannelAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetSlackChannel(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_channel_splunk.go
+++ b/lacework/resource_lacework_alert_channel_splunk.go
@@ -169,7 +169,7 @@ func resourceLaceworkAlertChannelSplunkRead(d *schema.ResourceData, meta interfa
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.SplunkHecAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetSplunkHec(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	integration := response.Data

--- a/lacework/resource_lacework_alert_channel_splunk.go
+++ b/lacework/resource_lacework_alert_channel_splunk.go
@@ -169,7 +169,7 @@ func resourceLaceworkAlertChannelSplunkRead(d *schema.ResourceData, meta interfa
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.SplunkHecAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetSplunkHec(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	integration := response.Data

--- a/lacework/resource_lacework_alert_channel_victorops.go
+++ b/lacework/resource_lacework_alert_channel_victorops.go
@@ -113,7 +113,7 @@ func resourceLaceworkAlertChannelVictorOpsRead(d *schema.ResourceData, meta inte
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.VictorOpsAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetVictorOps(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	integration := response.Data

--- a/lacework/resource_lacework_alert_channel_victorops.go
+++ b/lacework/resource_lacework_alert_channel_victorops.go
@@ -113,7 +113,7 @@ func resourceLaceworkAlertChannelVictorOpsRead(d *schema.ResourceData, meta inte
 	log.Printf("[INFO] Reading %s integration with guid %s\n", api.VictorOpsAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetVictorOps(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	integration := response.Data

--- a/lacework/resource_lacework_alert_channel_webhook.go
+++ b/lacework/resource_lacework_alert_channel_webhook.go
@@ -114,7 +114,7 @@ func resourceLaceworkAlertChannelWebhookRead(d *schema.ResourceData, meta interf
 	log.Printf("[INFO] Reading %s integration with guid: %v\n", api.WebhookAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetWebhook(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_channel_webhook.go
+++ b/lacework/resource_lacework_alert_channel_webhook.go
@@ -114,7 +114,7 @@ func resourceLaceworkAlertChannelWebhookRead(d *schema.ResourceData, meta interf
 	log.Printf("[INFO] Reading %s integration with guid: %v\n", api.WebhookAlertChannelType, d.Id())
 	response, err := lacework.V2.AlertChannels.GetWebhook(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_alert_profile.go
+++ b/lacework/resource_lacework_alert_profile.go
@@ -109,7 +109,7 @@ func resourceLaceworkAlertProfileRead(d *schema.ResourceData, meta interface{}) 
 	log.Printf("[INFO] Reading alert profile with id: %s\n", d.Id())
 	err := lacework.V2.Alert.Profiles.Get(d.Id(), &response)
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.SetId(response.Data.Guid)

--- a/lacework/resource_lacework_alert_profile.go
+++ b/lacework/resource_lacework_alert_profile.go
@@ -109,7 +109,7 @@ func resourceLaceworkAlertProfileRead(d *schema.ResourceData, meta interface{}) 
 	log.Printf("[INFO] Reading alert profile with id: %s\n", d.Id())
 	err := lacework.V2.Alert.Profiles.Get(d.Id(), &response)
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.SetId(response.Data.Guid)

--- a/lacework/resource_lacework_alert_rule.go
+++ b/lacework/resource_lacework_alert_rule.go
@@ -201,7 +201,7 @@ func resourceLaceworkAlertRuleRead(d *schema.ResourceData, meta interface{}) err
 	log.Printf("[INFO] Reading alert rule with guid %s\n", d.Id())
 	err := lacework.V2.AlertRules.Get(d.Id(), &response)
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.SetId(response.Data.Guid)

--- a/lacework/resource_lacework_alert_rule.go
+++ b/lacework/resource_lacework_alert_rule.go
@@ -201,7 +201,7 @@ func resourceLaceworkAlertRuleRead(d *schema.ResourceData, meta interface{}) err
 	log.Printf("[INFO] Reading alert rule with guid %s\n", d.Id())
 	err := lacework.V2.AlertRules.Get(d.Id(), &response)
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.SetId(response.Data.Guid)

--- a/lacework/resource_lacework_integration_aws_cfg.go
+++ b/lacework/resource_lacework_integration_aws_cfg.go
@@ -150,7 +150,7 @@ func resourceLaceworkIntegrationAwsCfgRead(d *schema.ResourceData, meta interfac
 		api.AwsCfgIntegration.String(), d.Id())
 	response, err := lacework.Integrations.GetAws(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	for _, integration := range response.Data {

--- a/lacework/resource_lacework_integration_aws_cfg.go
+++ b/lacework/resource_lacework_integration_aws_cfg.go
@@ -150,7 +150,7 @@ func resourceLaceworkIntegrationAwsCfgRead(d *schema.ResourceData, meta interfac
 		api.AwsCfgIntegration.String(), d.Id())
 	response, err := lacework.Integrations.GetAws(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	for _, integration := range response.Data {

--- a/lacework/resource_lacework_integration_aws_ct.go
+++ b/lacework/resource_lacework_integration_aws_ct.go
@@ -198,7 +198,7 @@ func resourceLaceworkIntegrationAwsCloudTrailRead(d *schema.ResourceData, meta i
 	log.Printf("[INFO] Reading %s cloud account integration with guid: %v\n", api.AwsCtSqsCloudAccount.String(), d.Id())
 	response, err := lacework.V2.CloudAccounts.GetAwsCtSqs(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	cloudAccount := response.Data

--- a/lacework/resource_lacework_integration_aws_ct.go
+++ b/lacework/resource_lacework_integration_aws_ct.go
@@ -198,7 +198,7 @@ func resourceLaceworkIntegrationAwsCloudTrailRead(d *schema.ResourceData, meta i
 	log.Printf("[INFO] Reading %s cloud account integration with guid: %v\n", api.AwsCtSqsCloudAccount.String(), d.Id())
 	response, err := lacework.V2.CloudAccounts.GetAwsCtSqs(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	cloudAccount := response.Data

--- a/lacework/resource_lacework_integration_aws_eks_audit_log.go
+++ b/lacework/resource_lacework_integration_aws_eks_audit_log.go
@@ -151,7 +151,7 @@ func resourceLaceworkIntegrationAwsEksAuditLogRead(d *schema.ResourceData, meta 
 	log.Printf("[INFO] Reading %s cloud account integration with guid: %v\n", api.AwsEksAuditCloudAccount.String(), d.Id())
 	response, err := lacework.V2.CloudAccounts.GetAwsEksAudit(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	cloudAccount := response.Data

--- a/lacework/resource_lacework_integration_aws_eks_audit_log.go
+++ b/lacework/resource_lacework_integration_aws_eks_audit_log.go
@@ -151,7 +151,7 @@ func resourceLaceworkIntegrationAwsEksAuditLogRead(d *schema.ResourceData, meta 
 	log.Printf("[INFO] Reading %s cloud account integration with guid: %v\n", api.AwsEksAuditCloudAccount.String(), d.Id())
 	response, err := lacework.V2.CloudAccounts.GetAwsEksAudit(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	cloudAccount := response.Data

--- a/lacework/resource_lacework_integration_aws_govcloud_cfg.go
+++ b/lacework/resource_lacework_integration_aws_govcloud_cfg.go
@@ -158,7 +158,7 @@ func resourceLaceworkIntegrationAwsGovCloudCfgRead(d *schema.ResourceData, meta 
 		api.AwsGovCloudCfgIntegration.String(), d.Id())
 	response, err := lacework.Integrations.GetAws(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	for _, integration := range response.Data {

--- a/lacework/resource_lacework_integration_aws_govcloud_cfg.go
+++ b/lacework/resource_lacework_integration_aws_govcloud_cfg.go
@@ -158,7 +158,7 @@ func resourceLaceworkIntegrationAwsGovCloudCfgRead(d *schema.ResourceData, meta 
 		api.AwsGovCloudCfgIntegration.String(), d.Id())
 	response, err := lacework.Integrations.GetAws(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	for _, integration := range response.Data {

--- a/lacework/resource_lacework_integration_aws_govcloud_ct.go
+++ b/lacework/resource_lacework_integration_aws_govcloud_ct.go
@@ -164,7 +164,7 @@ func resourceLaceworkIntegrationAwsGovCloudCTRead(d *schema.ResourceData, meta i
 		api.AwsGovCloudCTIntegration.String(), d.Id())
 	response, err := lacework.Integrations.GetAws(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	for _, integration := range response.Data {

--- a/lacework/resource_lacework_integration_aws_govcloud_ct.go
+++ b/lacework/resource_lacework_integration_aws_govcloud_ct.go
@@ -164,7 +164,7 @@ func resourceLaceworkIntegrationAwsGovCloudCTRead(d *schema.ResourceData, meta i
 		api.AwsGovCloudCTIntegration.String(), d.Id())
 	response, err := lacework.Integrations.GetAws(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	for _, integration := range response.Data {

--- a/lacework/resource_lacework_integration_azure_cfg.go
+++ b/lacework/resource_lacework_integration_azure_cfg.go
@@ -164,7 +164,7 @@ func resourceLaceworkIntegrationAzureCfgRead(d *schema.ResourceData, meta interf
 		api.AzureCfgIntegration.String(), d.Id())
 	response, err := lacework.Integrations.GetAzure(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	for _, integration := range response.Data {

--- a/lacework/resource_lacework_integration_azure_cfg.go
+++ b/lacework/resource_lacework_integration_azure_cfg.go
@@ -164,7 +164,7 @@ func resourceLaceworkIntegrationAzureCfgRead(d *schema.ResourceData, meta interf
 		api.AzureCfgIntegration.String(), d.Id())
 	response, err := lacework.Integrations.GetAzure(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	for _, integration := range response.Data {

--- a/lacework/resource_lacework_integration_docker_hub.go
+++ b/lacework/resource_lacework_integration_docker_hub.go
@@ -212,7 +212,7 @@ func resourceLaceworkIntegrationDockerHubRead(d *schema.ResourceData, meta inter
 	response, err := lacework.Integrations.GetContainerRegistry(d.Id())
 
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	for _, integration := range response.Data {

--- a/lacework/resource_lacework_integration_docker_hub.go
+++ b/lacework/resource_lacework_integration_docker_hub.go
@@ -212,7 +212,7 @@ func resourceLaceworkIntegrationDockerHubRead(d *schema.ResourceData, meta inter
 	response, err := lacework.Integrations.GetContainerRegistry(d.Id())
 
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	for _, integration := range response.Data {

--- a/lacework/resource_lacework_integration_docker_v2.go
+++ b/lacework/resource_lacework_integration_docker_v2.go
@@ -194,7 +194,7 @@ func resourceLaceworkIntegrationDockerV2Read(d *schema.ResourceData, meta interf
 	response, err := lacework.Integrations.GetContainerRegistry(d.Id())
 
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	for _, integration := range response.Data {

--- a/lacework/resource_lacework_integration_docker_v2.go
+++ b/lacework/resource_lacework_integration_docker_v2.go
@@ -194,7 +194,7 @@ func resourceLaceworkIntegrationDockerV2Read(d *schema.ResourceData, meta interf
 	response, err := lacework.Integrations.GetContainerRegistry(d.Id())
 
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	for _, integration := range response.Data {

--- a/lacework/resource_lacework_integration_ecr.go
+++ b/lacework/resource_lacework_integration_ecr.go
@@ -263,7 +263,7 @@ func resourceLaceworkIntegrationEcrReadWithIAMRole(d *schema.ResourceData, lacew
 		api.ContainerRegistryIntegration.String(), api.EcrRegistry.String(), d.Id())
 	response, err := lacework.Integrations.GetAwsEcrWithCrossAccount(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	for _, integration := range response.Data {
@@ -320,7 +320,7 @@ func resourceLaceworkIntegrationEcrReadWithAccessKey(d *schema.ResourceData, lac
 		api.ContainerRegistryIntegration.String(), api.EcrRegistry.String(), d.Id())
 	response, err := lacework.Integrations.GetAwsEcrWithAccessKey(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	for _, integration := range response.Data {

--- a/lacework/resource_lacework_integration_ecr.go
+++ b/lacework/resource_lacework_integration_ecr.go
@@ -263,7 +263,7 @@ func resourceLaceworkIntegrationEcrReadWithIAMRole(d *schema.ResourceData, lacew
 		api.ContainerRegistryIntegration.String(), api.EcrRegistry.String(), d.Id())
 	response, err := lacework.Integrations.GetAwsEcrWithCrossAccount(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	for _, integration := range response.Data {
@@ -320,7 +320,7 @@ func resourceLaceworkIntegrationEcrReadWithAccessKey(d *schema.ResourceData, lac
 		api.ContainerRegistryIntegration.String(), api.EcrRegistry.String(), d.Id())
 	response, err := lacework.Integrations.GetAwsEcrWithAccessKey(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	for _, integration := range response.Data {

--- a/lacework/resource_lacework_integration_gar.go
+++ b/lacework/resource_lacework_integration_gar.go
@@ -253,7 +253,7 @@ func resourceLaceworkIntegrationGarRead(d *schema.ResourceData, meta interface{}
 		api.GcpGarContainerRegistry.String(), d.Id())
 	response, err := lacework.V2.ContainerRegistries.GetGcpGar(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_integration_gar.go
+++ b/lacework/resource_lacework_integration_gar.go
@@ -253,7 +253,7 @@ func resourceLaceworkIntegrationGarRead(d *schema.ResourceData, meta interface{}
 		api.GcpGarContainerRegistry.String(), d.Id())
 	response, err := lacework.V2.ContainerRegistries.GetGcpGar(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_integration_gcp_at.go
+++ b/lacework/resource_lacework_integration_gcp_at.go
@@ -216,7 +216,7 @@ func resourceLaceworkIntegrationGcpAtRead(d *schema.ResourceData, meta interface
 	response, err := lacework.Integrations.GetGcp(d.Id())
 
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	for _, integration := range response.Data {

--- a/lacework/resource_lacework_integration_gcp_at.go
+++ b/lacework/resource_lacework_integration_gcp_at.go
@@ -216,7 +216,7 @@ func resourceLaceworkIntegrationGcpAtRead(d *schema.ResourceData, meta interface
 	response, err := lacework.Integrations.GetGcp(d.Id())
 
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	for _, integration := range response.Data {

--- a/lacework/resource_lacework_integration_gcp_cfg.go
+++ b/lacework/resource_lacework_integration_gcp_cfg.go
@@ -208,7 +208,7 @@ func resourceLaceworkIntegrationGcpCfgRead(d *schema.ResourceData, meta interfac
 		api.GcpCfgIntegration.String(), d.Id())
 	response, err := lacework.Integrations.GetGcp(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	for _, integration := range response.Data {

--- a/lacework/resource_lacework_integration_gcp_cfg.go
+++ b/lacework/resource_lacework_integration_gcp_cfg.go
@@ -208,7 +208,7 @@ func resourceLaceworkIntegrationGcpCfgRead(d *schema.ResourceData, meta interfac
 		api.GcpCfgIntegration.String(), d.Id())
 	response, err := lacework.Integrations.GetGcp(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	for _, integration := range response.Data {

--- a/lacework/resource_lacework_integration_gcr.go
+++ b/lacework/resource_lacework_integration_gcr.go
@@ -255,7 +255,7 @@ func resourceLaceworkIntegrationGcrRead(d *schema.ResourceData, meta interface{}
 	response, err := lacework.Integrations.GetContainerRegistry(d.Id())
 
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	for _, integration := range response.Data {

--- a/lacework/resource_lacework_integration_gcr.go
+++ b/lacework/resource_lacework_integration_gcr.go
@@ -255,7 +255,7 @@ func resourceLaceworkIntegrationGcrRead(d *schema.ResourceData, meta interface{}
 	response, err := lacework.Integrations.GetContainerRegistry(d.Id())
 
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	for _, integration := range response.Data {

--- a/lacework/resource_lacework_integration_ghcr.go
+++ b/lacework/resource_lacework_integration_ghcr.go
@@ -187,7 +187,7 @@ func resourceLaceworkIntegrationGhcrRead(d *schema.ResourceData, meta interface{
 		api.GhcrContainerRegistry.String(), d.Id())
 	response, err := lacework.V2.ContainerRegistries.GetGhcr(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_integration_ghcr.go
+++ b/lacework/resource_lacework_integration_ghcr.go
@@ -187,7 +187,7 @@ func resourceLaceworkIntegrationGhcrRead(d *schema.ResourceData, meta interface{
 		api.GhcrContainerRegistry.String(), d.Id())
 	response, err := lacework.V2.ContainerRegistries.GetGhcr(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.Set("name", response.Data.Name)

--- a/lacework/resource_lacework_policy.go
+++ b/lacework/resource_lacework_policy.go
@@ -190,7 +190,7 @@ func resourceLaceworkPolicyRead(d *schema.ResourceData, meta interface{}) error 
 	log.Printf("[INFO] Reading Policy with guid %s\n", d.Id())
 	response, err := lacework.V2.Policy.Get(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.SetId(response.Data.PolicyID)

--- a/lacework/resource_lacework_policy.go
+++ b/lacework/resource_lacework_policy.go
@@ -190,7 +190,7 @@ func resourceLaceworkPolicyRead(d *schema.ResourceData, meta interface{}) error 
 	log.Printf("[INFO] Reading Policy with guid %s\n", d.Id())
 	response, err := lacework.V2.Policy.Get(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.SetId(response.Data.PolicyID)

--- a/lacework/resource_lacework_query.go
+++ b/lacework/resource_lacework_query.go
@@ -85,7 +85,7 @@ func resourceLaceworkQueryRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Reading Query with guid %s\n", d.Id())
 	response, err := lacework.V2.Query.Get(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.Set("query", response.Data.QueryText)

--- a/lacework/resource_lacework_query.go
+++ b/lacework/resource_lacework_query.go
@@ -85,7 +85,7 @@ func resourceLaceworkQueryRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Reading Query with guid %s\n", d.Id())
 	response, err := lacework.V2.Query.Get(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.Set("query", response.Data.QueryText)

--- a/lacework/resource_lacework_report_rule.go
+++ b/lacework/resource_lacework_report_rule.go
@@ -361,7 +361,7 @@ func resourceLaceworkReportRuleRead(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[INFO] Reading report rule with guid %s\n", d.Id())
 	err := lacework.V2.ReportRules.Get(d.Id(), &response)
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.SetId(response.Data.Guid)

--- a/lacework/resource_lacework_report_rule.go
+++ b/lacework/resource_lacework_report_rule.go
@@ -361,7 +361,7 @@ func resourceLaceworkReportRuleRead(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[INFO] Reading report rule with guid %s\n", d.Id())
 	err := lacework.V2.ReportRules.Get(d.Id(), &response)
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.SetId(response.Data.Guid)

--- a/lacework/resource_lacework_resource_group_account.go
+++ b/lacework/resource_lacework_resource_group_account.go
@@ -123,7 +123,7 @@ func resourceLaceworkResourceGroupLwAccountRead(d *schema.ResourceData, meta int
 		api.LwAccountResourceGroup.String(), d.Id())
 	response, err := lacework.V2.ResourceGroups.GetLwAccount(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.SetId(response.Data.ResourceGuid)

--- a/lacework/resource_lacework_resource_group_account.go
+++ b/lacework/resource_lacework_resource_group_account.go
@@ -1,10 +1,11 @@
 package lacework
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/lacework/go-sdk/api"
 	"log"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/lacework/go-sdk/api"
 )
 
 func resourceLaceworkResourceGroupLwAccount() *schema.Resource {
@@ -122,7 +123,7 @@ func resourceLaceworkResourceGroupLwAccountRead(d *schema.ResourceData, meta int
 		api.LwAccountResourceGroup.String(), d.Id())
 	response, err := lacework.V2.ResourceGroups.GetLwAccount(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.SetId(response.Data.ResourceGuid)

--- a/lacework/resource_lacework_resource_group_aws.go
+++ b/lacework/resource_lacework_resource_group_aws.go
@@ -124,7 +124,7 @@ func resourceLaceworkResourceGroupAwsRead(d *schema.ResourceData, meta interface
 		api.AwsResourceGroup.String(), d.Id())
 	response, err := lacework.V2.ResourceGroups.GetAws(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.SetId(response.Data.ResourceGuid)

--- a/lacework/resource_lacework_resource_group_aws.go
+++ b/lacework/resource_lacework_resource_group_aws.go
@@ -1,9 +1,10 @@
 package lacework
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"log"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/lacework/go-sdk/api"
 )
@@ -123,7 +124,7 @@ func resourceLaceworkResourceGroupAwsRead(d *schema.ResourceData, meta interface
 		api.AwsResourceGroup.String(), d.Id())
 	response, err := lacework.V2.ResourceGroups.GetAws(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.SetId(response.Data.ResourceGuid)

--- a/lacework/resource_lacework_resource_group_azure.go
+++ b/lacework/resource_lacework_resource_group_azure.go
@@ -1,9 +1,10 @@
 package lacework
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"log"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/lacework/go-sdk/api"
 )
@@ -129,7 +130,7 @@ func resourceLaceworkResourceGroupAzureRead(d *schema.ResourceData, meta interfa
 		api.AzureResourceGroup.String(), d.Id())
 	response, err := lacework.V2.ResourceGroups.GetAzure(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.SetId(response.Data.ResourceGuid)

--- a/lacework/resource_lacework_resource_group_azure.go
+++ b/lacework/resource_lacework_resource_group_azure.go
@@ -130,7 +130,7 @@ func resourceLaceworkResourceGroupAzureRead(d *schema.ResourceData, meta interfa
 		api.AzureResourceGroup.String(), d.Id())
 	response, err := lacework.V2.ResourceGroups.GetAzure(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.SetId(response.Data.ResourceGuid)

--- a/lacework/resource_lacework_resource_group_container.go
+++ b/lacework/resource_lacework_resource_group_container.go
@@ -142,7 +142,7 @@ func resourceLaceworkResourceGroupContainerRead(d *schema.ResourceData, meta int
 		api.ContainerResourceGroup.String(), d.Id())
 	response, err := lacework.V2.ResourceGroups.GetContainer(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.SetId(response.Data.ResourceGuid)

--- a/lacework/resource_lacework_resource_group_container.go
+++ b/lacework/resource_lacework_resource_group_container.go
@@ -1,10 +1,11 @@
 package lacework
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/lacework/go-sdk/api"
 	"log"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/lacework/go-sdk/api"
 )
 
 func resourceLaceworkResourceGroupContainer() *schema.Resource {
@@ -141,7 +142,7 @@ func resourceLaceworkResourceGroupContainerRead(d *schema.ResourceData, meta int
 		api.ContainerResourceGroup.String(), d.Id())
 	response, err := lacework.V2.ResourceGroups.GetContainer(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.SetId(response.Data.ResourceGuid)

--- a/lacework/resource_lacework_resource_group_gcp.go
+++ b/lacework/resource_lacework_resource_group_gcp.go
@@ -1,9 +1,10 @@
 package lacework
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"log"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/lacework/go-sdk/api"
 )
@@ -129,7 +130,7 @@ func resourceLaceworkResourceGroupGcpRead(d *schema.ResourceData, meta interface
 		api.GcpResourceGroup.String(), d.Id())
 	response, err := lacework.V2.ResourceGroups.GetGcp(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.SetId(response.Data.ResourceGuid)

--- a/lacework/resource_lacework_resource_group_gcp.go
+++ b/lacework/resource_lacework_resource_group_gcp.go
@@ -130,7 +130,7 @@ func resourceLaceworkResourceGroupGcpRead(d *schema.ResourceData, meta interface
 		api.GcpResourceGroup.String(), d.Id())
 	response, err := lacework.V2.ResourceGroups.GetGcp(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.SetId(response.Data.ResourceGuid)

--- a/lacework/resource_lacework_resource_group_machine.go
+++ b/lacework/resource_lacework_resource_group_machine.go
@@ -1,9 +1,10 @@
 package lacework
 
 import (
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/lacework/go-sdk/api"
-	"log"
 )
 
 func resourceLaceworkResourceGroupMachine() *schema.Resource {
@@ -128,7 +129,7 @@ func resourceLaceworkResourceGroupMachineRead(d *schema.ResourceData, meta inter
 		api.MachineResourceGroup.String(), d.Id())
 	response, err := lacework.V2.ResourceGroups.GetMachine(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.SetId(response.Data.ResourceGuid)

--- a/lacework/resource_lacework_resource_group_machine.go
+++ b/lacework/resource_lacework_resource_group_machine.go
@@ -129,7 +129,7 @@ func resourceLaceworkResourceGroupMachineRead(d *schema.ResourceData, meta inter
 		api.MachineResourceGroup.String(), d.Id())
 	response, err := lacework.V2.ResourceGroups.GetMachine(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.SetId(response.Data.ResourceGuid)

--- a/lacework/resource_lacework_vulnerability_exception_container.go
+++ b/lacework/resource_lacework_vulnerability_exception_container.go
@@ -275,7 +275,7 @@ func resourceLaceworkVulnerabilityExceptionContainerRead(d *schema.ResourceData,
 	log.Printf("[INFO] Reading vulnerability exception with guid %s\n", d.Id())
 	err := lacework.V2.VulnerabilityExceptions.Get(d.Id(), &response)
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.SetId(response.Data.Guid)

--- a/lacework/resource_lacework_vulnerability_exception_container.go
+++ b/lacework/resource_lacework_vulnerability_exception_container.go
@@ -275,7 +275,7 @@ func resourceLaceworkVulnerabilityExceptionContainerRead(d *schema.ResourceData,
 	log.Printf("[INFO] Reading vulnerability exception with guid %s\n", d.Id())
 	err := lacework.V2.VulnerabilityExceptions.Get(d.Id(), &response)
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.SetId(response.Data.Guid)

--- a/lacework/resource_lacework_vulnerability_exception_host.go
+++ b/lacework/resource_lacework_vulnerability_exception_host.go
@@ -261,7 +261,7 @@ func resourceLaceworkVulnerabilityExceptionHostRead(d *schema.ResourceData, meta
 	log.Printf("[INFO] Reading vulnerability exception with guid %s\n", d.Id())
 	response, err := lacework.V2.VulnerabilityExceptions.GetVulnerabilityExceptionsHost(d.Id())
 	if err != nil {
-		return err
+		return resourceNotFound(d, err, d.Id())
 	}
 
 	d.SetId(response.Data.Guid)

--- a/lacework/resource_lacework_vulnerability_exception_host.go
+++ b/lacework/resource_lacework_vulnerability_exception_host.go
@@ -261,7 +261,7 @@ func resourceLaceworkVulnerabilityExceptionHostRead(d *schema.ResourceData, meta
 	log.Printf("[INFO] Reading vulnerability exception with guid %s\n", d.Id())
 	response, err := lacework.V2.VulnerabilityExceptions.GetVulnerabilityExceptionsHost(d.Id())
 	if err != nil {
-		return resourceNotFound(d, err, d.Id())
+		return resourceNotFound(d, err)
 	}
 
 	d.SetId(response.Data.Guid)


### PR DESCRIPTION
Signed-off-by: Darren Murray <darren.murray@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-provider-lacework/blob/main/CONTRIBUTING.md
--->

***Issue***: https://lacework.atlassian.net/browse/ALLY-981

***Description:***
Handle Read resource when a resource has been deleted outside of Terraform scope. This change will remove the deleted resource from Terraform state. The old behaviour printed the api not found error.

