### PR TITLE
feat: add tags field to policy resource

### DIFF
--- a/examples/resource_lacework_policy/main.tf
+++ b/examples/resource_lacework_policy/main.tf
@@ -16,6 +16,7 @@ resource "lacework_policy" "example" {
   evaluation       = var.evaluation
   enabled          = true
   policy_id_suffix = var.policy_id_suffix
+  tags = var.tags
 
   alerting {
     enabled = false
@@ -58,6 +59,11 @@ variable "policy_id_suffix" {
   default = ""
 }
 
+variable "tags" {
+  type = list(string)
+  default = ["domain:AWS", "custom"]
+}
+
 output "title" {
   value = lacework_policy.example.title
 }
@@ -86,3 +92,6 @@ output "policy_id_suffix" {
   value = lacework_policy.example.policy_id_suffix
 }
 
+output "tags" {
+  value = lacework_policy.example.tags
+}

--- a/examples/resource_lacework_policy/main.tf
+++ b/examples/resource_lacework_policy/main.tf
@@ -16,7 +16,7 @@ resource "lacework_policy" "example" {
   evaluation       = var.evaluation
   enabled          = true
   policy_id_suffix = var.policy_id_suffix
-  tags = var.tags
+  tags             = var.tags
 
   alerting {
     enabled = false

--- a/integration/resource_lacework_policy_test.go
+++ b/integration/resource_lacework_policy_test.go
@@ -26,6 +26,7 @@ func TestPolicyCreate(t *testing.T) {
 			"description": "Policy Created via Terraform",
 			"remediation": "Please Investigate",
 			"evaluation":  "Hourly",
+			"tags":        []string{"domain:AWS", "subdomain:Cloudtrail"},
 		},
 	})
 	defer terraform.Destroy(t, terraformOptions)
@@ -40,6 +41,7 @@ func TestPolicyCreate(t *testing.T) {
 	actualDescription := terraform.Output(t, terraformOptions, "description")
 	actualRemediation := terraform.Output(t, terraformOptions, "remediation")
 	actualEvaluation := terraform.Output(t, terraformOptions, "evaluation")
+	actualTags := terraform.Output(t, terraformOptions, "tags")
 
 	assert.Contains(t, "lql-terraform-policy", createProps.Data.Title)
 	assert.Contains(t, "high", createProps.Data.Severity)
@@ -47,6 +49,7 @@ func TestPolicyCreate(t *testing.T) {
 	assert.Contains(t, "Policy Created via Terraform", createProps.Data.Description)
 	assert.Contains(t, "Please Investigate", createProps.Data.Remediation)
 	assert.Contains(t, "Hourly", createProps.Data.EvalFrequency)
+	assert.Equal(t, []string{"domain:AWS", "subdomain:Cloudtrail"}, createProps.Data.Tags)
 
 	assert.Equal(t, "lql-terraform-policy", actualTitle)
 	assert.Equal(t, "high", actualSeverity)
@@ -54,6 +57,7 @@ func TestPolicyCreate(t *testing.T) {
 	assert.Equal(t, "Policy Created via Terraform", actualDescription)
 	assert.Equal(t, "Please Investigate", actualRemediation)
 	assert.Equal(t, "Hourly", actualEvaluation)
+	assert.Equal(t, "[domain:AWS subdomain:Cloudtrail]", actualTags)
 
 	// Update Policy
 	terraformOptions.Vars = map[string]interface{}{
@@ -63,6 +67,7 @@ func TestPolicyCreate(t *testing.T) {
 		"description": "Policy Created via Terraform Updated",
 		"remediation": "Please Ignore",
 		"evaluation":  "Daily",
+		"tags":        []string{"domain:AWS", "subdomain:Cloudtrail", "custom"},
 	}
 
 	update := terraform.ApplyAndIdempotent(t, terraformOptions)
@@ -74,6 +79,7 @@ func TestPolicyCreate(t *testing.T) {
 	actualDescription = terraform.Output(t, terraformOptions, "description")
 	actualRemediation = terraform.Output(t, terraformOptions, "remediation")
 	actualEvaluation = terraform.Output(t, terraformOptions, "evaluation")
+	actualTags = terraform.Output(t, terraformOptions, "tags")
 
 	assert.Contains(t, "lql-terraform-policy-updated", updateProps.Data.Title)
 	assert.Contains(t, "low", updateProps.Data.Severity)
@@ -81,6 +87,7 @@ func TestPolicyCreate(t *testing.T) {
 	assert.Contains(t, "Policy Created via Terraform Updated", updateProps.Data.Description)
 	assert.Contains(t, "Please Ignore", updateProps.Data.Remediation)
 	assert.Contains(t, "Daily", updateProps.Data.EvalFrequency)
+	assert.Equal(t, []string{"custom", "domain:AWS", "subdomain:Cloudtrail"}, updateProps.Data.Tags)
 
 	assert.Equal(t, "lql-terraform-policy-updated", actualTitle)
 	assert.Equal(t, "low", actualSeverity)
@@ -88,6 +95,7 @@ func TestPolicyCreate(t *testing.T) {
 	assert.Equal(t, "Policy Created via Terraform Updated", actualDescription)
 	assert.Equal(t, "Please Ignore", actualRemediation)
 	assert.Equal(t, "Daily", actualEvaluation)
+	assert.Equal(t, "[custom domain:AWS subdomain:Cloudtrail]", actualTags)
 }
 
 func TestPolicyCreateWithPolicyIDSuffix(t *testing.T) {
@@ -149,5 +157,4 @@ func TestPolicyCreateWithPolicyIDSuffix(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Contains(t, msg, "unable to change ID of an existing policy")
-
 }

--- a/lacework/resource_lacework_policy.go
+++ b/lacework/resource_lacework_policy.go
@@ -151,9 +151,9 @@ func resourceLaceworkPolicy() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"generated_tags": {
+			"computed_tags": {
 				Type:        schema.TypeString,
-				Description: "All policy tags, including server generated tags",
+				Description: "All policy tags, server generated and user specified tags",
 				Computed:    true,
 			},
 		},
@@ -191,7 +191,7 @@ func resourceLaceworkPolicyCreate(d *schema.ResourceData, meta interface{}) erro
 	d.Set("owner", response.Data.Owner)
 	d.Set("updated_time", response.Data.LastUpdateTime)
 	d.Set("updated_by", response.Data.LastUpdateUser)
-	d.Set("generated_tags", strings.Join(response.Data.Tags, ","))
+	d.Set("computed_tags", strings.Join(response.Data.Tags, ","))
 
 	log.Printf("[INFO] Created Policy with guid %s\n", response.Data.PolicyID)
 	return nil
@@ -221,7 +221,7 @@ func resourceLaceworkPolicyRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("owner", response.Data.Owner)
 	d.Set("updated_time", response.Data.LastUpdateTime)
 	d.Set("updated_by", response.Data.LastUpdateUser)
-	d.Set("generated_tags", strings.Join(response.Data.Tags, ","))
+	d.Set("computed_tags", strings.Join(response.Data.Tags, ","))
 
 	alerting := make(map[string]interface{})
 	alerting["enabled"] = response.Data.AlertEnabled
@@ -271,7 +271,7 @@ func resourceLaceworkPolicyUpdate(d *schema.ResourceData, meta interface{}) erro
 	d.Set("owner", response.Data.Owner)
 	d.Set("updated_time", response.Data.LastUpdateTime)
 	d.Set("updated_by", response.Data.LastUpdateUser)
-	d.Set("generated_tags", strings.Join(response.Data.Tags, ","))
+	d.Set("computed_tags", strings.Join(response.Data.Tags, ","))
 
 	log.Printf("[INFO] Updated Policy with guid %s\n", response.Data.PolicyID)
 	return nil

--- a/lacework/resource_lacework_policy.go
+++ b/lacework/resource_lacework_policy.go
@@ -143,6 +143,14 @@ func resourceLaceworkPolicy() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"tags": {
+				Type:        schema.TypeSet,
+				Description: "A list of policy tags",
+				Optional:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }
@@ -165,6 +173,7 @@ func resourceLaceworkPolicyCreate(d *schema.ResourceData, meta interface{}) erro
 		AlertEnabled:  d.Get("alerting.0.enabled").(bool),
 		AlertProfile:  d.Get("alerting.0.profile").(string),
 		PolicyID:      d.Get("policy_id_suffix").(string),
+		Tags:          castStringSlice(d.Get("tags").(*schema.Set).List()),
 	}
 
 	log.Printf("[INFO] Creating Policy with data:\n%+v\n", policy)
@@ -177,6 +186,7 @@ func resourceLaceworkPolicyCreate(d *schema.ResourceData, meta interface{}) erro
 	d.Set("owner", response.Data.Owner)
 	d.Set("updated_time", response.Data.LastUpdateTime)
 	d.Set("updated_by", response.Data.LastUpdateUser)
+	d.Set("tags", response.Data.Tags)
 
 	log.Printf("[INFO] Created Policy with guid %s\n", response.Data.PolicyID)
 	return nil
@@ -206,6 +216,7 @@ func resourceLaceworkPolicyRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("owner", response.Data.Owner)
 	d.Set("updated_time", response.Data.LastUpdateTime)
 	d.Set("updated_by", response.Data.LastUpdateUser)
+	d.Set("tags", response.Data.Tags)
 
 	alerting := make(map[string]interface{})
 	alerting["enabled"] = response.Data.AlertEnabled
@@ -242,6 +253,7 @@ func resourceLaceworkPolicyUpdate(d *schema.ResourceData, meta interface{}) erro
 		AlertEnabled:  &alertingEnabled,
 		AlertProfile:  d.Get("alerting.0.profile").(string),
 		PolicyID:      d.Id(),
+		Tags:          castStringSlice(d.Get("tags").(*schema.Set).List()),
 	}
 
 	log.Printf("[INFO] Updating Policy with data:\n%+v\n", policy)

--- a/lacework/resource_lacework_policy.go
+++ b/lacework/resource_lacework_policy.go
@@ -106,6 +106,14 @@ func resourceLaceworkPolicy() *schema.Resource {
 				Default:     true,
 				Description: "The state of the policy",
 			},
+			"tags": {
+				Type:        schema.TypeSet,
+				Description: "A list of user specified policy tags",
+				Optional:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"alerting": {
 				Type:        schema.TypeList,
 				MaxItems:    1,
@@ -143,13 +151,10 @@ func resourceLaceworkPolicy() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags": {
-				Type:        schema.TypeSet,
-				Description: "A list of policy tags",
-				Optional:    true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+			"generated_tags": {
+				Type:        schema.TypeString,
+				Description: "All policy tags, including server generated tags",
+				Computed:    true,
 			},
 		},
 	}
@@ -186,7 +191,7 @@ func resourceLaceworkPolicyCreate(d *schema.ResourceData, meta interface{}) erro
 	d.Set("owner", response.Data.Owner)
 	d.Set("updated_time", response.Data.LastUpdateTime)
 	d.Set("updated_by", response.Data.LastUpdateUser)
-	d.Set("tags", response.Data.Tags)
+	d.Set("generated_tags", strings.Join(response.Data.Tags, ","))
 
 	log.Printf("[INFO] Created Policy with guid %s\n", response.Data.PolicyID)
 	return nil
@@ -216,7 +221,7 @@ func resourceLaceworkPolicyRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("owner", response.Data.Owner)
 	d.Set("updated_time", response.Data.LastUpdateTime)
 	d.Set("updated_by", response.Data.LastUpdateUser)
-	d.Set("tags", response.Data.Tags)
+	d.Set("generated_tags", strings.Join(response.Data.Tags, ","))
 
 	alerting := make(map[string]interface{})
 	alerting["enabled"] = response.Data.AlertEnabled
@@ -266,6 +271,7 @@ func resourceLaceworkPolicyUpdate(d *schema.ResourceData, meta interface{}) erro
 	d.Set("owner", response.Data.Owner)
 	d.Set("updated_time", response.Data.LastUpdateTime)
 	d.Set("updated_by", response.Data.LastUpdateUser)
+	d.Set("generated_tags", strings.Join(response.Data.Tags, ","))
 
 	log.Printf("[INFO] Updated Policy with guid %s\n", response.Data.PolicyID)
 	return nil

--- a/website/docs/r/policy.html.markdown
+++ b/website/docs/r/policy.html.markdown
@@ -50,6 +50,7 @@ resource "lacework_policy" "example" {
   severity    = "High"
   type        = "Violation"
   evaluation  = "Hourly"
+  tags        = ["domain:AWS", "custom"]
   enabled     = false
 
   alerting {
@@ -81,6 +82,7 @@ The following arguments are supported:
    Maximum value is `5000`. Defaults to `1000`
 * `enabled` - (Optional) Whether the policy is enabled or disabled. Defaults to `true`.
 * `policy_id_suffix` - (Optional) The string appended to the end of the policy id.
+* `tags` - (Optional) A list of policy tags.
 * `alerting` - (Optional) Alerting. See [Alerting](#alerting) below for details.
 
 ### Alerting


### PR DESCRIPTION
Signed-off-by: Darren Murray <darren.murray@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-provider-lacework/blob/main/CONTRIBUTING.md
--->

***Issue***: 
https://lacework.atlassian.net/browse/ALLY-988

***Description:***
Add `tags` field to policy resource
Add computed field `generated_tags` to policy resource

Some policy tags will be automatically added by the server, to prevent tf state diff issues there are 2 fields for tags. User provided tags, in the `tags` field. And a computed field `generated_tags` 