### PR TITLE
feat(AwsEksAudit): Add S3BucketArn field to allow BYOB for AWS EKS Audit Log

### DIFF
--- a/examples/resource_lacework_integration_aws_eks_audit_log/main.tf
+++ b/examples/resource_lacework_integration_aws_eks_audit_log/main.tf
@@ -26,9 +26,15 @@ variable "role_arn" {
   default   = "arn:aws:iam::249446771485:role/lacework-iam-example-role"
 }
 
+variable "bucket_arn" {
+  type      = string
+  default   = "arn:aws:s3:::lacework-example-eks-bucket"
+}
+
 resource "lacework_integration_aws_eks_audit_log" "example" {
-  name    = var.name
-  sns_arn = var.sns_arn
+  name       = var.name
+  sns_arn    = var.sns_arn
+  bucket_arn = var.bucket_arn
   credentials {
     role_arn    = var.role_arn
     external_id = var.external_id
@@ -42,6 +48,10 @@ output "name" {
 
 output "sns_arn" {
   value = lacework_integration_aws_eks_audit_log.example.sns_arn
+}
+
+output "bucket_arn" {
+  value = lacework_integration_aws_eks_audit_log.example.bucket_arn
 }
 
 output "role_arn" {

--- a/integration/resource_lacework_integration_aws_eks_audit_log_test.go
+++ b/integration/resource_lacework_integration_aws_eks_audit_log_test.go
@@ -19,6 +19,7 @@ func TestIntegrationAwsEksAuditLog(t *testing.T) {
 			"role_arn":    "arn:aws:iam::249446771485:role/lacework-iam-example-role",
 			"external_id": "12345",
 			"sns_arn":     "arn:aws:sns:us-west-2:123456789123:foo-lacework-eks",
+			"bucket_arn":  "arn:aws:s3:::lacework-example-eks-bucket",
 		},
 	})
 	defer terraform.Destroy(t, terraformOptions)
@@ -29,6 +30,7 @@ func TestIntegrationAwsEksAuditLog(t *testing.T) {
 	actualRoleArn := terraform.Output(t, terraformOptions, "role_arn")
 	actualExternalId := terraform.Output(t, terraformOptions, "external_id")
 	actualSnsArn := terraform.Output(t, terraformOptions, "sns_arn")
+	actualBucketArn := terraform.Output(t, terraformOptions, "bucket_arn")
 	assert.Equal(
 		t,
 		"AWS EKS audit log integration example",
@@ -40,6 +42,7 @@ func TestIntegrationAwsEksAuditLog(t *testing.T) {
 	assert.Equal(t, "arn:aws:iam::249446771485:role/lacework-iam-example-role", actualRoleArn)
 	assert.Equal(t, "12345", actualExternalId)
 	assert.Equal(t, "arn:aws:sns:us-west-2:123456789123:foo-lacework-eks", actualSnsArn)
+	assert.Equal(t, "arn:aws:s3:::lacework-example-eks-bucket", actualBucketArn)
 
 	// Update AwsEksAudit Integration
 	terraformOptions.Vars = map[string]interface{}{
@@ -54,6 +57,7 @@ func TestIntegrationAwsEksAuditLog(t *testing.T) {
 	actualRoleArn = terraform.Output(t, terraformOptions, "role_arn")
 	actualExternalId = terraform.Output(t, terraformOptions, "external_id")
 	actualSnsArn = terraform.Output(t, terraformOptions, "sns_arn")
+	actualBucketArn = terraform.Output(t, terraformOptions, "bucket_arn")
 	assert.Equal(
 		t,
 		"AwsEksAudit log integration updated",
@@ -65,4 +69,5 @@ func TestIntegrationAwsEksAuditLog(t *testing.T) {
 	assert.Equal(t, "arn:aws:iam::249446771485:role/lacework-iam-example-role", actualRoleArn)
 	assert.Equal(t, "12345", actualExternalId)
 	assert.Equal(t, "arn:aws:sns:us-west-2:123456789123:foo-lacework-eks", actualSnsArn)
+	assert.Equal(t, "arn:aws:s3:::lacework-example-eks-bucket", actualBucketArn)
 }

--- a/lacework/resource_lacework_integration_aws_eks_audit_log.go
+++ b/lacework/resource_lacework_integration_aws_eks_audit_log.go
@@ -90,7 +90,8 @@ func resourceLaceworkIntegrationAwsEksAuditLogCreate(d *schema.ResourceData, met
 		lacework           = meta.(*api.Client)
 		retries            = d.Get("retries").(int)
 		awsEksAuditLogData = api.AwsEksAuditData{
-			SnsArn: d.Get("sns_arn").(string),
+			SnsArn:      d.Get("sns_arn").(string),
+			S3BucketArn: d.Get("bucket_arn").(string),
 			Credentials: api.AwsEksAuditCredentials{
 				RoleArn:    d.Get("credentials.0.role_arn").(string),
 				ExternalID: d.Get("credentials.0.external_id").(string),
@@ -170,6 +171,7 @@ func resourceLaceworkIntegrationAwsEksAuditLogRead(d *schema.ResourceData, meta 
 		creds["external_id"] = credentials.ExternalID
 		d.Set("credentials", []map[string]string{creds})
 		d.Set("snsArn", cloudAccount.Data.SnsArn)
+		d.Set("s3BucketArn", cloudAccount.Data.S3BucketArn)
 
 		log.Printf("[INFO] Read %s cloud account integration with guid: %v\n",
 			api.AwsEksAuditCloudAccount.String(), cloudAccount.IntgGuid,
@@ -185,7 +187,8 @@ func resourceLaceworkIntegrationAwsEksAuditLogUpdate(d *schema.ResourceData, met
 	var (
 		lacework           = meta.(*api.Client)
 		awsEksAuditLogData = api.AwsEksAuditData{
-			SnsArn: d.Get("sns_arn").(string),
+			SnsArn:      d.Get("sns_arn").(string),
+			S3BucketArn: d.Get("bucket_arn").(string),
 			Credentials: api.AwsEksAuditCredentials{
 				RoleArn:    d.Get("credentials.0.role_arn").(string),
 				ExternalID: d.Get("credentials.0.external_id").(string),

--- a/website/docs/r/integration_aws_eks_audit_log.html.markdown
+++ b/website/docs/r/integration_aws_eks_audit_log.html.markdown
@@ -23,12 +23,26 @@ resource "lacework_integration_aws_eks_audit_log" "account_abc" {
 }
 ```
 
+Bring your own bucket:
+```hcl
+resource "lacework_integration_aws_eks_audit_log" "account_abc" {
+  name      = "account ABC"
+  sns_arn   = "arn:aws:sns:us-west-2:123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d"
+  bucket_arn = "arn:aws:s3:::lacework-example-eks-bucket"
+  credentials {
+    role_arn    = "arn:aws:iam::1234567890:role/lacework_iam_example_role"
+    external_id = "12345"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `name` - (Required) The AWS CloudTrail integration name.
+* `name` - (Required) The AWS EKS Audit Log integration name.
 * `sns_arn` - (Required) The SNS topic ARN to share with Lacework.
+* `bucket_arn` - (Optional) If supplied, the integration will use this bucket rather than creating a new bucket.
 * `credentials` - (Required) The credentials needed by the integration. See [Credentials](#credentials) below for details.
 * `enabled` - (Optional) The state of the external integration. Defaults to `true`.
 * `retries` - (Optional) The number of attempts to create the cloud account integration. Defaults to `5`.


### PR DESCRIPTION
Signed-off-by: Ross <ross.moles@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

Adding `S3BucketArn` to the AwsEksAudit schema to enable BYOB for customer integrations

blocked by https://github.com/lacework/rainbow/pull/8699 & https://github.com/lacework/go-sdk/pull/793

## How did you test this change?

Currently only unit tests. 

## Issue

https://lacework.atlassian.net/browse/ALLY-993
