### PR TITLE
fix: time parse error for expiry field

### DIFF
--- a/examples/resource_lacework_vulnerability_exception_host/main.tf
+++ b/examples/resource_lacework_vulnerability_exception_host/main.tf
@@ -10,7 +10,7 @@ resource "lacework_vulnerability_exception_host" "example" {
   name        = var.name
   description = var.description
   enabled     = true
-  expiry      = "2023-06-06T15:55:15Z"
+  expiry      = var.expiry
   reason      = "Accepted Risk"
   vulnerability_criteria {
     severities = ["Critical"]
@@ -35,6 +35,41 @@ resource "lacework_vulnerability_exception_host" "example" {
     external_ips  = ["210.12.100.5"]
     namespaces    = ["namespace1", "namespace2"]
   }
+}
+
+resource "lacework_vulnerability_exception_host" "no_expiry" {
+  name        = var.name
+  description = var.description
+  enabled     = true
+  reason      = "Accepted Risk"
+  vulnerability_criteria {
+    severities = ["Critical"]
+    cves       = var.cves
+    package {
+      name    = var.package_name
+      version = var.package_version
+    }
+    package {
+      name    = "myPackage"
+      version = "2.0.0"
+    }
+    package {
+      name    = "myOtherPackage"
+      version = "1.0.0"
+    }
+    fixable = true
+  }
+  resource_scope {
+    hostnames     = ["host1", "host2"]
+    cluster_names = ["clust-abc", "clust-xyz"]
+    external_ips  = ["210.12.100.5"]
+    namespaces    = ["namespace1", "namespace2"]
+  }
+}
+
+variable "expiry" {
+  type    = string
+  default = "2023-06-06T15:55:15Z"
 }
 
 variable "name" {

--- a/integration/resource_lacework_vulnerability_exception_container_test.go
+++ b/integration/resource_lacework_vulnerability_exception_container_test.go
@@ -42,6 +42,9 @@ func TestVulnerabilityExceptionContainerCreate(t *testing.T) {
 	assert.Equal(t, "[CVE-2016-9840 CVE-2018-14599 CVE-2018-6942]", actualCves)
 	assert.Equal(t, "[map[name:adm-zip version:0.4.7] map[name:myPackage version:1.0.0]]", actualPackages)
 
+	noexpiry := GetSpecificIDFromTerraResults(2, create)
+	assert.NotEmpty(t, noexpiry)
+
 	// Update Vulnerability Exception
 	terraformOptions.Vars = map[string]interface{}{
 		"name":            "Terraform Vulnerability Exception Container Test",

--- a/integration/resource_lacework_vulnerability_exception_container_test.go
+++ b/integration/resource_lacework_vulnerability_exception_container_test.go
@@ -42,9 +42,6 @@ func TestVulnerabilityExceptionContainerCreate(t *testing.T) {
 	assert.Equal(t, "[CVE-2016-9840 CVE-2018-14599 CVE-2018-6942]", actualCves)
 	assert.Equal(t, "[map[name:adm-zip version:0.4.7] map[name:myPackage version:1.0.0]]", actualPackages)
 
-	noexpiry := GetSpecificIDFromTerraResults(2, create)
-	assert.NotEmpty(t, noexpiry)
-
 	// Update Vulnerability Exception
 	terraformOptions.Vars = map[string]interface{}{
 		"name":            "Terraform Vulnerability Exception Container Test",

--- a/integration/resource_lacework_vulnerability_exception_host_test.go
+++ b/integration/resource_lacework_vulnerability_exception_host_test.go
@@ -41,6 +41,9 @@ func TestVulnerabilityExceptionHostCreate(t *testing.T) {
 	assert.Equal(t, "[CVE-2016-9840 CVE-2018-14599 CVE-2018-6942]", actualCves)
 	assert.Equal(t, "[map[name:myOtherPackage version:1.0.0] map[name:myPackage version:1.0.0] map[name:myPackage version:2.0.0]]", actualPackages)
 
+	noexpiry := GetSpecificIDFromTerraResults(2, create)
+	assert.NotEmpty(t, noexpiry)
+
 	// Update Vulnerability Exception
 	terraformOptions.Vars = map[string]interface{}{
 		"name":            "Terraform Vulnerability Exception Host Test",

--- a/lacework/resource_lacework_vulnerability_exception_container.go
+++ b/lacework/resource_lacework_vulnerability_exception_container.go
@@ -240,7 +240,7 @@ func resourceLaceworkVulnerabilityExceptionContainerCreate(d *schema.ResourceDat
 		}
 	)
 
-	if d.Get("expiry") != nil {
+	if d.Get("expiry") != nil && d.Get("expiry") != "" {
 		expiryTime, err := time.Parse(time.RFC3339, d.Get("expiry").(string))
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("unable to parse expiry time %s", d.Get("expiry").(string)))
@@ -345,7 +345,7 @@ func resourceLaceworkVulnerabilityExceptionContainerUpdate(d *schema.ResourceDat
 		}
 	)
 
-	if d.Get("expiry") != nil {
+	if d.Get("expiry") != nil && d.Get("expiry") != "" {
 		expiryTime, err := time.Parse(time.RFC3339, d.Get("expiry").(string))
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("unable to parse expiry time %s", d.Get("expiry").(string)))

--- a/lacework/resource_lacework_vulnerability_exception_host.go
+++ b/lacework/resource_lacework_vulnerability_exception_host.go
@@ -229,7 +229,7 @@ func resourceLaceworkVulnerabilityExceptionHostCreate(d *schema.ResourceData, me
 			Fixable:         d.Get("vulnerability_criteria.0.fixable").(bool),
 		}
 	)
-	if d.Get("expiry") != nil {
+	if d.Get("expiry") != nil && d.Get("expiry") != "" {
 		expiryTime, err := time.Parse(time.RFC3339, d.Get("expiry").(string))
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("unable to parse expiry time %s", d.Get("expiry").(string)))
@@ -332,7 +332,7 @@ func resourceLaceworkVulnerabilityExceptionHostUpdate(d *schema.ResourceData, me
 		}
 	)
 
-	if d.Get("expiry") != nil {
+	if d.Get("expiry") != nil && d.Get("expiry") != "" {
 		expiryTime, err := time.Parse(time.RFC3339, d.Get("expiry").(string))
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("unable to parse expiry time %s", d.Get("expiry").(string)))


### PR DESCRIPTION
***Issue***:  https://lacework.atlassian.net/browse/ALLY-1055

***Description:***
- Check for empty string before attempting to parse expiry
- Add  integration test with no expiry field
