### PR TITLE
test: Use unique API token for all integration tests

### DIFF
--- a/integration/integration.go
+++ b/integration/integration.go
@@ -11,11 +11,26 @@ import (
 var (
 	LwClient    *api.Client
 	LwOrgClient *api.Client
+	LwApiToken  string
+	tokenEnvVar map[string]string
 )
 
 func init() {
 	LwClient = lwTestCLient()
 	LwOrgClient = lwOrgTestClient()
+	LwApiToken = generateUniqueApiToken()
+	tokenEnvVar = map[string]string{
+		"LW_API_TOKEN": LwApiToken,
+	}
+}
+
+func generateUniqueApiToken() string {
+	token, err := LwClient.GenerateToken()
+	if err != nil {
+		log.Fatalf("Failed to generate API token, %v", err)
+	}
+
+	return token.Token
 }
 
 func lwTestCLient() (lw *api.Client) {

--- a/integration/resource_lacework_agent_access_token_test.go
+++ b/integration/resource_lacework_agent_access_token_test.go
@@ -18,6 +18,7 @@ func TestAgentAccessTokenCreate(t *testing.T) {
 	// Create new Agent Access Token
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_agent_access_token",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"token_name": tokenName,
 		},
@@ -31,6 +32,7 @@ func TestAgentAccessTokenCreate(t *testing.T) {
 	// Read Agent Access Token
 	dataTerraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/data_source_lacework_agent_access_token",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"token_name": tokenName,
 		}})

--- a/integration/resource_lacework_alert_channel_aws_cloudwatch_test.go
+++ b/integration/resource_lacework_alert_channel_aws_cloudwatch_test.go
@@ -21,6 +21,7 @@ func TestAlertChannelCloudWatchCreate(t *testing.T) {
 		},
 		EnvVars: map[string]string{
 			"TF_VAR_event_bus_arn": eventBusArn,
+			"LW_API_TOKEN":         LwApiToken,
 		},
 	})
 	defer terraform.Destroy(t, terraformOptions)

--- a/integration/resource_lacework_alert_channel_aws_s3_test.go
+++ b/integration/resource_lacework_alert_channel_aws_s3_test.go
@@ -24,6 +24,7 @@ func TestAlertChannelAwsS3Create(t *testing.T) {
 			},
 			EnvVars: map[string]string{
 				"TF_VAR_bucket_arn": s3BucketArn,
+				"LW_API_TOKEN":      LwApiToken,
 			},
 		})
 		defer terraform.Destroy(t, terraformOptions)

--- a/integration/resource_lacework_alert_channel_cisco_webex_test.go
+++ b/integration/resource_lacework_alert_channel_cisco_webex_test.go
@@ -15,6 +15,7 @@ import (
 func TestAlertChannelCiscoWebexCreate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_channel_cisco_webex",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"channel_name": "Cisco Webex Alert Channel Example",
 			"webhook_url":  "https://webexapis.com/v1/webhooks/incoming/api-token",

--- a/integration/resource_lacework_alert_channel_datadog_test.go
+++ b/integration/resource_lacework_alert_channel_datadog_test.go
@@ -14,6 +14,7 @@ func TestDatadogAlertChannelCreate(t *testing.T) {
 	apiKey := "vatasha-fake-dd-api-key"
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_channel_datadog",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"channel_name":    "Datadog Alert Channel Example",
 			"datadog_site":    "com",

--- a/integration/resource_lacework_alert_channel_email_test.go
+++ b/integration/resource_lacework_alert_channel_email_test.go
@@ -15,6 +15,7 @@ import (
 func TestAlertChannelEmailCreate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_channel_email",
+		EnvVars:      tokenEnvVar,
 	})
 	defer terraform.Destroy(t, terraformOptions)
 

--- a/integration/resource_lacework_alert_channel_gcp_pub_sub_test.go
+++ b/integration/resource_lacework_alert_channel_gcp_pub_sub_test.go
@@ -28,6 +28,7 @@ func TestAlertChannelGcpPubSubCreate(t *testing.T) {
 			},
 			EnvVars: map[string]string{
 				"TF_VAR_private_key": gcreds.PrivateKey,
+				"LW_API_TOKEN":       LwApiToken,
 			},
 		})
 		defer terraform.Destroy(t, terraformOptions)
@@ -48,6 +49,7 @@ func TestAlertChannelGcpPubSubCreate(t *testing.T) {
 		}
 		terraformOptions.EnvVars = map[string]string{
 			"TF_VAR_private_key": gcreds.PrivateKey,
+			"LW_API_TOKEN":       LwApiToken,
 		}
 
 		update := terraform.ApplyAndIdempotent(t, terraformOptions)

--- a/integration/resource_lacework_alert_channel_ibm_qradar_test.go
+++ b/integration/resource_lacework_alert_channel_ibm_qradar_test.go
@@ -13,6 +13,7 @@ import (
 func TestIbmQRadarAlertChannelCreate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_channel_qradar",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"channel_name":       "IbmQRadar Alert Channel Example",
 			"host_url":           "https://qradar-lacework.com",

--- a/integration/resource_lacework_alert_channel_jira_cloud_test.go
+++ b/integration/resource_lacework_alert_channel_jira_cloud_test.go
@@ -15,6 +15,7 @@ import (
 func TestAlertChannelJiraCloudCreate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_channel_jira_cloud",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"channel_name":    "My Jira Cloud Example",
 			"jira_url":        "test-lacework.atlassian.net",

--- a/integration/resource_lacework_alert_channel_jira_server_test.go
+++ b/integration/resource_lacework_alert_channel_jira_server_test.go
@@ -15,6 +15,7 @@ import (
 func TestAlertChannelJiraServerCreate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_channel_jira_server",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"channel_name":    "My Jira Server Example",
 			"jira_url":        "test-lacework.atlassian.net",

--- a/integration/resource_lacework_alert_channel_microsoft_teams_test.go
+++ b/integration/resource_lacework_alert_channel_microsoft_teams_test.go
@@ -15,6 +15,7 @@ import (
 func TestAlertChannelMicrosoftTeams(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_channel_microsoft_teams",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"channel_name": "Test Name",
 			"webhook_url":  "https://outlook.office.com/webhook/api-token",

--- a/integration/resource_lacework_alert_channel_slack_test.go
+++ b/integration/resource_lacework_alert_channel_slack_test.go
@@ -15,6 +15,7 @@ import (
 func TestAlertChannelSlackCreate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_channel_slack",
+		EnvVars:      tokenEnvVar,
 	})
 	defer terraform.Destroy(t, terraformOptions)
 

--- a/integration/resource_lacework_alert_channel_webhook_test.go
+++ b/integration/resource_lacework_alert_channel_webhook_test.go
@@ -13,6 +13,7 @@ import (
 func TestWebhookAlertChannelCreate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_channel_webhook",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"channel_name": "Webhook Alert Channel Example",
 			"webhook_url":  "https://hook.com/webhook?api-token=123",

--- a/integration/resource_lacework_alert_profile_test.go
+++ b/integration/resource_lacework_alert_profile_test.go
@@ -15,6 +15,7 @@ import (
 func TestAlertProfileCreate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_profile",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"name":    "CUSTOM_PROFILE_TERRAFORM_TEST",
 			"extends": "LW_CFG_GCP_DEFAULT_PROFILE",
@@ -65,6 +66,7 @@ func TestAlertProfileCreate(t *testing.T) {
 func TestAlertProfileValidate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_profile",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"name":    "LW_PROFILE_TERRAFORM_TEST",
 			"extends": "LW_CFG_GCP_DEFAULT_PROFILE",

--- a/integration/resource_lacework_alert_rule_test.go
+++ b/integration/resource_lacework_alert_rule_test.go
@@ -21,6 +21,7 @@ func _TestAlertRuleCreate(t *testing.T) {
 	name := fmt.Sprintf("Alert Rule - %s", time.Now())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_rule",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"name":                name,
 			"description":         "Alert Rule created by Terraform",
@@ -94,6 +95,7 @@ func _TestAlertRuleSeverities(t *testing.T) {
 	name := fmt.Sprintf("Alert Rule - %s", time.Now())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_rule",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"name":                name,
 			"severities":          []string{"Critical", "high", "mEdIuM", "LOW"},
@@ -137,6 +139,7 @@ func _TestAlertRuleCategories(t *testing.T) {
 	name := fmt.Sprintf("Alert Rule - %s", time.Now())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_rule",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"name":                name,
 			"event_categories":    []string{"Compliance", "APP", "CloUD", "fIlE", "machine", "uSER", "PlatforM"},

--- a/integration/resource_lacework_integration_aws_eks_audit_log_test.go
+++ b/integration/resource_lacework_integration_aws_eks_audit_log_test.go
@@ -15,6 +15,7 @@ import (
 func TestIntegrationAwsEksAuditLog(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_integration_aws_eks_audit_log",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"role_arn":    "arn:aws:iam::249446771485:role/lacework-iam-example-role",
 			"external_id": "12345",

--- a/integration/resource_lacework_integration_ecr_test.go
+++ b/integration/resource_lacework_integration_ecr_test.go
@@ -18,6 +18,7 @@ func TestIntegrationECRCreate(t *testing.T) {
 	if assert.Nil(t, err, "this test requires you to set AWS_ECR_IAM environment variable") {
 		terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 			TerraformDir: "../examples/resource_lacework_integration_ecr/iam_role",
+			EnvVars:      tokenEnvVar,
 			Vars: map[string]interface{}{
 				"integration_name":       "Amazon Elastic Container Registry Example",
 				"role_arn":               awsCreds.RoleArn,
@@ -53,6 +54,7 @@ func TestIntegrationECRCreate(t *testing.T) {
 func TestIntegrationECRNumImagesValidation(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_integration_ecr/iam_role",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"integration_name": "Amazon Elastic Container Registry Example",
 			"num_images":       0,
@@ -93,6 +95,7 @@ func TestIntegrationECRNumImagesValidation(t *testing.T) {
 	//Test omit num images
 	terraformOptions = terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_integration_ecr/iam_role",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"integration_name": "Amazon Elastic Container Registry Example",
 		},

--- a/integration/resource_lacework_integration_gar_test.go
+++ b/integration/resource_lacework_integration_gar_test.go
@@ -25,6 +25,7 @@ func TestIntegrationGARCreate(t *testing.T) {
 			},
 			EnvVars: map[string]string{
 				"TF_VAR_private_key": gcreds.PrivateKey, // @afiune this will avoid printing secrets in our pipeline
+				"LW_API_TOKEN":       LwApiToken,
 			},
 		})
 		defer terraform.Destroy(t, terraformOptions)

--- a/integration/resource_lacework_integration_gcp_gke_audit_log_test.go
+++ b/integration/resource_lacework_integration_gcp_gke_audit_log_test.go
@@ -17,6 +17,7 @@ func TestIntegrationGcpGkeAuditLog(t *testing.T) {
 	if assert.Nil(t, err, "this test requires you to set GOOGLE_CREDENTIALS environment variable") {
 		terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 			TerraformDir: "../examples/resource_lacework_integration_gcp_gke_audit_log",
+			EnvVars:      tokenEnvVar,
 			Vars: map[string]interface{}{
 				"name":             "GCP GKE audit log integration example",
 				"client_id":        gcreds.ClientID,

--- a/integration/resource_lacework_integration_ghcr_test.go
+++ b/integration/resource_lacework_integration_ghcr_test.go
@@ -24,6 +24,7 @@ func TestIntegrationGHCRCreate(t *testing.T) {
 			},
 			EnvVars: map[string]string{
 				"TF_VAR_password": creds.Token,
+				"LW_API_TOKEN":    LwApiToken,
 			},
 		})
 		defer terraform.Destroy(t, terraformOptions)

--- a/integration/resource_lacework_integration_newrelic_test.go
+++ b/integration/resource_lacework_integration_newrelic_test.go
@@ -13,6 +13,7 @@ import (
 func TestNewRelicAlertChannelCreate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_channel_newrelic",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"channel_name": "NewRelic Insights Alert Channel Example",
 			"insert_key":   "x-xx-xxxxxxxxxxxxxxxxxx",

--- a/integration/resource_lacework_integration_pagerduty_test.go
+++ b/integration/resource_lacework_integration_pagerduty_test.go
@@ -13,6 +13,7 @@ import (
 func TestPagerDutyAlertChannelCreate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_channel_pagerduty",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"channel_name":    "PagerDuty Alert Channel Example",
 			"integration_key": "1234abc8901abc567abc123abc78e012",

--- a/integration/resource_lacework_integration_service_now_test.go
+++ b/integration/resource_lacework_integration_service_now_test.go
@@ -13,6 +13,7 @@ import (
 func TestServiceNowRestAlertChannelCreate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_channel_service_now",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"channel_name":         "Service Now Alert Channel Example",
 			"instance_url":         "https://dev123.service-now.com",

--- a/integration/resource_lacework_integration_splunk_test.go
+++ b/integration/resource_lacework_integration_splunk_test.go
@@ -13,6 +13,7 @@ import (
 func TestSplunkAlertChannelCreate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_channel_splunk",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"channel_name": "Splunk Alert Channel Example",
 			"channel":      "Splunk Channel",

--- a/integration/resource_lacework_integration_victorops_test.go
+++ b/integration/resource_lacework_integration_victorops_test.go
@@ -13,6 +13,7 @@ import (
 func TestVictorOpsAlertChannelCreate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_channel_victorops",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"channel_name": "VictorOps Alert Channel Example",
 			"webhook_url":  "https://alert.victorops.com/integrations/generic/20131114/alert/31e945ee-5cad-44e7-afb0-97c20ea80dd8/database",

--- a/integration/resource_lacework_policy_exception_test.go
+++ b/integration/resource_lacework_policy_exception_test.go
@@ -15,6 +15,7 @@ import (
 func TestPolicyExceptionCreate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_policy_exception",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"policy_id":    "lacework-global-46",
 			"description":  "Policy Exception Created via Terraform",

--- a/integration/resource_lacework_policy_test.go
+++ b/integration/resource_lacework_policy_test.go
@@ -19,6 +19,7 @@ import (
 func TestPolicyCreate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_policy",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"title":       "lql-terraform-policy",
 			"severity":    "High",

--- a/integration/resource_lacework_query_test.go
+++ b/integration/resource_lacework_query_test.go
@@ -19,6 +19,7 @@ func TestQueryCreateCloudtrail(t *testing.T) {
 	queryID := fmt.Sprintf("Lql_Terraform_Query_%d", time.Now().UnixMilli())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_query",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"query_id": queryID,
 			"query":    queryString},

--- a/integration/resource_lacework_report_rule_test.go
+++ b/integration/resource_lacework_report_rule_test.go
@@ -22,6 +22,7 @@ func _TestReportRuleCreate(t *testing.T) {
 	resourceGroupName := fmt.Sprintf("Used for Report Rule Test - %s", time.Now())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_report_rule",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"name":                name,
 			"description":         "Report Rule created by Terraform",

--- a/integration/resource_lacework_resource_group_account_test.go
+++ b/integration/resource_lacework_resource_group_account_test.go
@@ -22,6 +22,7 @@ func TestResourceGroupLwAccountCreate(t *testing.T) {
 	name := fmt.Sprintf("Terraform Test LwAccount Resource Group - %s", time.Now())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_resource_group_account",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"resource_group_name": name,
 			"description":         "Terraform Test LwAccount Resource Group",

--- a/integration/resource_lacework_resource_group_aws_test.go
+++ b/integration/resource_lacework_resource_group_aws_test.go
@@ -18,6 +18,7 @@ func TestResourceGroupAwsCreate(t *testing.T) {
 	name := fmt.Sprintf("Terraform Test Aws Resource Group - %s", time.Now())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_resource_group_aws",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"resource_group_name": name,
 			"description":         "Terraform Test Aws Resource Group",

--- a/integration/resource_lacework_resource_group_azure_test.go
+++ b/integration/resource_lacework_resource_group_azure_test.go
@@ -18,6 +18,7 @@ func TestResourceGroupAzureCreate(t *testing.T) {
 	name := fmt.Sprintf("Terraform Test Azure Resource Group - %s", time.Now())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_resource_group_azure",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"resource_group_name": name,
 			"description":         "Terraform Test Azure Resource Group",

--- a/integration/resource_lacework_resource_group_container_test.go
+++ b/integration/resource_lacework_resource_group_container_test.go
@@ -18,6 +18,7 @@ func TestResourceGroupContainerCreate(t *testing.T) {
 	name := fmt.Sprintf("Terraform Test Machine Resource Group - %s", time.Now())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_resource_group_container",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"resource_group_name": name,
 			"description":         "Terraform Test Container Resource Group",

--- a/integration/resource_lacework_resource_group_gcp_test.go
+++ b/integration/resource_lacework_resource_group_gcp_test.go
@@ -18,6 +18,7 @@ func TestResourceGroupGcpCreate(t *testing.T) {
 	name := fmt.Sprintf("Terraform Test LwAccount Resource Group - %s", time.Now())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_resource_group_gcp",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"resource_group_name": name,
 			"description":         "Terraform Test Gcp Resource Group",

--- a/integration/resource_lacework_resource_group_machine_test.go
+++ b/integration/resource_lacework_resource_group_machine_test.go
@@ -18,6 +18,7 @@ func TestResourceGroupMachineCreate(t *testing.T) {
 	name := fmt.Sprintf("Terraform Test Machine Resource Group - %s", time.Now())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_resource_group_machine",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"resource_group_name": name,
 			"description":         "Terraform Test Machine Resource Group",

--- a/integration/resource_lacework_team_member_test.go
+++ b/integration/resource_lacework_team_member_test.go
@@ -20,6 +20,7 @@ func TestTeamMemberStandalone(t *testing.T) {
 	email := fmt.Sprintf("vatasha.white+%d@lacework.net", time.Now().Unix())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_team_member_standalone",
+		EnvVars:      tokenEnvVar,
 		Vars:         map[string]interface{}{"email": email},
 	})
 	defer terraform.Destroy(t, terraformOptions)
@@ -64,6 +65,7 @@ func TestTeamMemberOrg(t *testing.T) {
 	}
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_team_member_organization",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"email":         email,
 			"user_accounts": []string{account},

--- a/integration/resource_lacework_vulnerability_exception_container_test.go
+++ b/integration/resource_lacework_vulnerability_exception_container_test.go
@@ -16,6 +16,7 @@ import (
 func TestVulnerabilityExceptionContainerCreate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_vulnerability_exception_container",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"name":            "Terraform Vulnerability Exception Container Test",
 			"description":     "Vulnerability Exception Container created by Terraform",

--- a/integration/resource_lacework_vulnerability_exception_host_test.go
+++ b/integration/resource_lacework_vulnerability_exception_host_test.go
@@ -15,6 +15,7 @@ import (
 func TestVulnerabilityExceptionHostCreate(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_vulnerability_exception_host",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"name":            "Terraform Vulnerability Exception Host Test",
 			"description":     "Vulnerability Exception Host created by Terraform",

--- a/integration/rollback_alert_channel_test.go
+++ b/integration/rollback_alert_channel_test.go
@@ -13,6 +13,7 @@ import (
 func TestAlertChannelRollback(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_channel_microsoft_teams",
+		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"channel_name":     "Test Name",
 			"webhook_url":      "https://outlook.office.com/webhook/api-token",


### PR DESCRIPTION
***Issue***: https://lacework.atlassian.net/browse/ALLY-1083

***Description:***
We are trying to avoid running into our own API Rate Limit by using a unique token for all
integration tests.