### PR TITLE
refactor: migrate agent_access_token to use v2 api

### DIFF
--- a/lacework/resource_lacework_agent_access_token.go
+++ b/lacework/resource_lacework_agent_access_token.go
@@ -43,10 +43,6 @@ func resourceLaceworkAgentAccessToken() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"account": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"version": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -70,33 +66,25 @@ func resourceLaceworkAgentAccessTokenCreate(d *schema.ResourceData, meta interfa
 
 	log.Printf("[INFO] Creating agent access token. name=%s, description=%s, enabled=%t",
 		tokenName, tokenDesc, tokenEnabled)
-	response, err := lacework.Agents.CreateToken(tokenName, tokenDesc)
+	response, err := lacework.V2.AgentAccessTokens.Create(tokenName, tokenDesc)
 	if err != nil {
 		return err
 	}
 
-	log.Println("[INFO] Verifying server response data")
-	err = validateAgentTokenResponse(&response)
-	if err != nil {
-		return err
-	}
-
-	// @afiune at this point in time, we know the data field has a value
-	token := response.Data[0]
+	token := response.Data
 	d.SetId(token.TokenAlias)
 	d.Set("name", token.TokenAlias)
 	d.Set("token", token.AccessToken)
 	d.Set("description", token.Props.Description)
-	d.Set("account", token.Account)
 	d.Set("version", token.Version)
-	d.Set("enabled", token.Status())
-	d.Set("last_updated_time", token.LastUpdatedTime.Format(time.RFC3339))
+	d.Set("enabled", token.State())
+	d.Set("last_updated_time", token.CreatedTime.Format(time.RFC3339))
 	d.Set("created_time", token.Props.CreatedTime.Format(time.RFC3339))
 
 	// very unusual but, if the user creates a token disabled, update its status
 	if !tokenEnabled {
 		log.Println("[INFO] Disabling agent access token.")
-		_, err = lacework.Agents.UpdateTokenStatus(token.AccessToken, false)
+		_, err = lacework.V2.AgentAccessTokens.Update(token.AccessToken, api.AgentAccessTokenRequest{Enabled: 0})
 		if err != nil {
 			return err
 		}
@@ -111,26 +99,24 @@ func resourceLaceworkAgentAccessTokenRead(d *schema.ResourceData, meta interface
 	lacework := meta.(*api.Client)
 
 	log.Printf("[INFO] Reading agent access token.")
-	response, err := lacework.Agents.GetToken(d.Get("token").(string))
+	response, err := lacework.V2.AgentAccessTokens.Get(d.Get("token").(string))
 	if err != nil {
 		return resourceNotFound(d, err)
 	}
 
-	for _, token := range response.Data {
-		if token.TokenAlias == d.Id() {
-			d.Set("name", token.TokenAlias)
-			d.Set("token", token.AccessToken)
-			d.Set("description", token.Props.Description)
-			d.Set("enabled", token.Status())
-			d.Set("account", token.Account)
-			d.Set("version", token.Version)
-			d.Set("last_updated_time", token.LastUpdatedTime.Format(time.RFC3339))
-			d.Set("created_time", token.Props.CreatedTime.Format(time.RFC3339))
+	token := response.Data
+	if token.TokenAlias == d.Id() {
+		d.Set("name", token.TokenAlias)
+		d.Set("token", token.AccessToken)
+		d.Set("description", token.Props.Description)
+		d.Set("enabled", token.State())
+		d.Set("version", token.Version)
+		d.Set("last_updated_time", token.CreatedTime.Format(time.RFC3339))
+		d.Set("created_time", token.Props.CreatedTime.Format(time.RFC3339))
 
-			log.Printf("[INFO] Read agent access token. name=%s, description=%s, enabled=%t",
-				token.TokenAlias, token.Props.Description, token.Status())
-			return nil
-		}
+		log.Printf("[INFO] Read agent access token. name=%s, description=%s, enabled=%t",
+			token.TokenAlias, token.Props.Description, token.State())
+		return nil
 	}
 
 	d.SetId("")
@@ -140,10 +126,10 @@ func resourceLaceworkAgentAccessTokenRead(d *schema.ResourceData, meta interface
 func resourceLaceworkAgentAccessTokenUpdate(d *schema.ResourceData, meta interface{}) error {
 	var (
 		lacework = meta.(*api.Client)
-		token    = api.AgentTokenRequest{
+		token    = api.AgentAccessTokenRequest{
 			TokenAlias: d.Get("name").(string),
 			Enabled:    0,
-			Props: &api.AgentTokenProps{
+			Props: &api.AgentAccessTokenProps{
 				Description: d.Get("description").(string),
 			},
 		}
@@ -155,27 +141,19 @@ func resourceLaceworkAgentAccessTokenUpdate(d *schema.ResourceData, meta interfa
 
 	log.Printf("[INFO] Updating agent access token. name=%s, description=%s, enabled=%t",
 		token.TokenAlias, token.Props.Description, d.Get("enabled").(bool))
-	response, err := lacework.Agents.UpdateToken(d.Get("token").(string), token)
+	response, err := lacework.V2.AgentAccessTokens.Update(d.Get("token").(string), token)
 	if err != nil {
 		return err
 	}
 
-	log.Println("[INFO] Verifying server response data")
-	err = validateAgentTokenResponse(&response)
-	if err != nil {
-		return err
-	}
-
-	// @afiune at this point in time, we know the data field has a value
-	nToken := response.Data[0]
+	nToken := response.Data
 	d.SetId(token.TokenAlias)
 	d.Set("name", nToken.TokenAlias)
 	d.Set("token", nToken.AccessToken)
 	d.Set("description", nToken.Props.Description)
-	d.Set("enabled", nToken.Status())
-	d.Set("account", nToken.Account)
+	d.Set("enabled", nToken.State())
 	d.Set("version", nToken.Version)
-	d.Set("last_updated_time", nToken.LastUpdatedTime.Format(time.RFC3339))
+	d.Set("last_updated_time", nToken.CreatedTime.Format(time.RFC3339))
 	d.Set("created_time", nToken.Props.CreatedTime.Format(time.RFC3339))
 
 	log.Printf("[INFO] Agent access token updated")
@@ -186,10 +164,6 @@ func resourceLaceworkAgentAccessTokenDelete(d *schema.ResourceData, meta interfa
 	var (
 		lacework  = meta.(*api.Client)
 		tokenName = fmt.Sprintf("%s-%s-deleted", d.Get("name").(string), randomString(5))
-		token     = api.AgentTokenRequest{
-			TokenAlias: tokenName,
-			Enabled:    0,
-		}
 	)
 
 	// @afiune agent access tokens, by design, cannot be deleted, instead of deleting
@@ -197,7 +171,7 @@ func resourceLaceworkAgentAccessTokenDelete(d *schema.ResourceData, meta interfa
 	// field has a unique constraint. There can't be two tokens with the same alias.
 
 	log.Printf("[INFO] Disabling agent access token. name=%s", tokenName)
-	_, err := lacework.Agents.UpdateToken(d.Get("token").(string), token)
+	_, err := lacework.V2.AgentAccessTokens.Update(d.Get("token").(string), api.AgentAccessTokenRequest{Enabled: 0, TokenAlias: tokenName})
 	if err != nil {
 		return err
 	}
@@ -232,24 +206,4 @@ func importLaceworkAgentAccessToken(d *schema.ResourceData, meta interface{}) ([
 		"Unable to import Lacework resource. Agent access token '%s' was not found.",
 		d.Id(),
 	)
-}
-
-// validateAgentTokenResponse checks weather or not the server response has
-// any inconsistent data, it returns a friendly error message describing the
-// problem and how to report it
-func validateAgentTokenResponse(response *api.AgentTokensResponse) error {
-	if len(response.Data) == 0 {
-		// @afiune this edge case should never happen, if we land here it means that
-		// something went wrong in the server side of things (Lacework API), so let
-		// us inform that to our users
-		msg := `
-Unable to read sever response data. (empty 'data' field)
-
-This was an unexpected behavior, verify that your agent token was
-created successfully and report this issue to support@lacework.net
-`
-		return fmt.Errorf(msg)
-	}
-
-	return nil
 }


### PR DESCRIPTION
Signed-off-by: Darren Murray <darren.murray@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-provider-lacework/blob/main/CONTRIBUTING.md
--->

***Issue***: 
https://lacework.atlassian.net/browse/ALLY-1125

***Description:***
migrate agent_access_token to use v2 api