### PR TITLE
fix: suppressdiff for gcp_cfg private_key_id

### DIFF
--- a/examples/resource_lacework_integration_gcp_cfg/main.tf
+++ b/examples/resource_lacework_integration_gcp_cfg/main.tf
@@ -1,14 +1,48 @@
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
 provider "lacework" {}
 
 resource "lacework_integration_gcp_cfg" "example" {
-  name = "Example-GCP-Integration"
+  name = var.integration_name
   credentials {
-    client_id      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-    private_key_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-    client_email   = "email@some-project-name.iam.gserviceaccount.com"
-    private_key    = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    client_id      = var.client_id
+    client_email   = var.client_email
+    private_key_id = var.private_key_id
+    private_key    = var.private_key
   }
   resource_level = "PROJECT"
-  resource_id    = "example-project_id"
+  resource_id    = "techally-test"
   retries        = 10
+}
+
+
+variable "integration_name" {
+  type    = string
+  default = "Google Cfg Example"
+}
+variable "client_id" {
+  type      = string
+  sensitive = true
+}
+variable "client_email" {
+  type      = string
+  sensitive = true
+}
+variable "private_key_id" {
+  type      = string
+  sensitive = true
+}
+variable "private_key" {
+  type      = string
+  sensitive = true
+}
+variable "non_os_package_support" {
+  type    = bool
+  default = true
 }

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -141,6 +141,18 @@ func GetContainerRegistryIntegration(result string) api.ContainerRegIntegration 
 	return res.Data[0]
 }
 
+func GetGcpCfgIntegration(result string) api.GcpCfgIntegrationResponse {
+	id := GetIDFromTerraResults(result)
+
+	res, err := LwClient.V2.CloudAccounts.GetGcpCfg(id)
+
+	if err != nil {
+		log.Fatalf("Unable to find integration id: %s\n Response: %v", id, res)
+	}
+
+	return res
+}
+
 func GetResourceGroupDescription(result string) string {
 	id := GetIDFromTerraResults(result)
 

--- a/integration/resource_lacework_integration_gcp_cfg_test.go
+++ b/integration/resource_lacework_integration_gcp_cfg_test.go
@@ -1,0 +1,44 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIntegrationGcpCfgCreate applies integration terraform:
+// => '../examples/resource_lacework_integration_gcp_cfg'
+//
+// It uses the go-sdk to verify the created integration,
+// applies an update with new integration name and destroys it
+func TestIntegrationGcpCfgCreate(t *testing.T) {
+	gcreds, err := googleLoadDefaultCredentials()
+	if assert.Nil(t, err, "this test requires you to set GOOGLE_CREDENTIALS environment variable") {
+		terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+			TerraformDir: "../examples/resource_lacework_integration_gcp_cfg",
+			Vars: map[string]interface{}{
+				"client_id":      gcreds.ClientID,
+				"client_email":   gcreds.ClientEmail,
+				"private_key_id": gcreds.PrivateKeyID,
+			},
+			EnvVars: map[string]string{
+				"TF_VAR_private_key": gcreds.PrivateKey,
+				"LW_API_TOKEN":       LwApiToken,
+			},
+		})
+		defer terraform.Destroy(t, terraformOptions)
+
+		// Create new Google Cfg
+		create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+		createData := GetGcpCfgIntegration(create)
+		assert.Equal(t, "Google Cfg Example", createData.Data.Name)
+
+		// Update Google Artifact Registry
+		terraformOptions.Vars["integration_name"] = "Google Cfg Updated"
+
+		update := terraform.ApplyAndIdempotent(t, terraformOptions)
+		updateData := GetContainerRegistryIntegration(update)
+		assert.Equal(t, "Google Cfg Updated", updateData.Name)
+	}
+}

--- a/lacework/resource_lacework_integration_gcp_cfg.go
+++ b/lacework/resource_lacework_integration_gcp_cfg.go
@@ -56,6 +56,13 @@ func resourceLaceworkIntegrationGcpCfg() *schema.Resource {
 						"private_key_id": {
 							Type:     schema.TypeString,
 							Required: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								return !d.HasChanges(
+									"name", "resource_level", "resource_id", "org_level", "enabled",
+									"credentials.0.client_id",
+									"credentials.0.client_email",
+								)
+							},
 						},
 						"client_email": {
 							Type:     schema.TypeString,
@@ -71,7 +78,7 @@ func resourceLaceworkIntegrationGcpCfg() *schema.Resource {
 								// any other element changed from the credentials then we trigger a diff
 								return !d.HasChanges(
 									"name", "resource_level", "resource_id", "org_level", "enabled",
-									"credentials.0.client_id", "credentials.0.private_key_id",
+									"credentials.0.client_id",
 									"credentials.0.client_email",
 								)
 							},


### PR DESCRIPTION
***Issue***: 
https://lacework.atlassian.net/browse/ALLY-1200

***Description:***
From v2 of the api the private key id field is a sensitive value and not returned. The diff needs to be suppressed for this field, otherwise there will be drift


***Additional Info:***
https://github.com/lacework/terraform-gcp-config/issues/70