### PR TITLE
docs: update deprecated cli cmd

### DIFF
--- a/website/docs/r/alert_channel_aws_cloudwatch.html.markdown
+++ b/website/docs/r/alert_channel_aws_cloudwatch.html.markdown
@@ -42,6 +42,6 @@ A Lacework Amazon CloudWatch Alert Channel integration can be imported using a `
 $ terraform import lacework_alert_channel_aws_cloudwatch.all_events EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework alert-channel list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).
 

--- a/website/docs/r/alert_channel_aws_s3.html.markdown
+++ b/website/docs/r/alert_channel_aws_s3.html.markdown
@@ -59,5 +59,5 @@ A Lacework Amazon S3 Alert Channel integration can be imported using a `INT_GUID
 $ terraform import lacework_alert_channel_aws_s3.data_export EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework alert-channel list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/alert_channel_cisco_webex.html.markdown
+++ b/website/docs/r/alert_channel_cisco_webex.html.markdown
@@ -37,5 +37,5 @@ A Lacework Cisco Webex Alert Channel integration can be imported using a `INT_GU
 $ terraform import lacework_alert_channel_cisco_webex.example EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework alert-channel list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/alert_channel_datadog.html.markdown
+++ b/website/docs/r/alert_channel_datadog.html.markdown
@@ -41,5 +41,5 @@ A Lacework Datadog Alert Channel integration can be imported using a `INT_GUID`,
 $ terraform import lacework_alert_channel_datadog.ops_critical EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework alert-channel list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/alert_channel_email.html.markdown
+++ b/website/docs/r/alert_channel_email.html.markdown
@@ -42,5 +42,5 @@ A Lacework Email Alert Channel integration can be imported using a `INT_GUID`, e
 $ terraform import lacework_alert_channel_email.auditors EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework alert-channel list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/alert_channel_gcp_pub_sub.html.markdown
+++ b/website/docs/r/alert_channel_gcp_pub_sub.html.markdown
@@ -56,5 +56,5 @@ A Lacework GCP Pub Sub Alert Channel integration can be imported using a `INT_GU
 $ terraform import lacework_alert_channel_gcp_pub_sub.data_export EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework alert-channel list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/alert_channel_jira_cloud.html.markdown
+++ b/website/docs/r/alert_channel_jira_cloud.html.markdown
@@ -56,6 +56,6 @@ A Lacework Jira Cloud Alert Channel integration can be imported using a `INT_GUI
 $ terraform import lacework_alert_channel_jira_cloud.example EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework alert-channel list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).
 

--- a/website/docs/r/alert_channel_jira_server.html.markdown
+++ b/website/docs/r/alert_channel_jira_server.html.markdown
@@ -57,6 +57,6 @@ A Lacework Jira Server Alert Channel integration can be imported using a `INT_GU
 $ terraform import lacework_alert_channel_jira_server.example EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework alert-channel list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).
 

--- a/website/docs/r/alert_channel_microsoft_teams.html.markdown
+++ b/website/docs/r/alert_channel_microsoft_teams.html.markdown
@@ -38,5 +38,5 @@ A Lacework Webhook Alert Channel integration can be imported using a `INT_GUID`,
 $ terraform import lacework_alert_channel_microsoft_teams.example EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework alert-channel list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/alert_channel_newrelic.html.markdown
+++ b/website/docs/r/alert_channel_newrelic.html.markdown
@@ -39,5 +39,5 @@ A Lacework New Relic Insights Alert Channel integration can be imported using a 
 $ terraform import lacework_alert_channel_newrelic.example EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework alert-channel list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/alert_channel_pagerduty.html.markdown
+++ b/website/docs/r/alert_channel_pagerduty.html.markdown
@@ -48,6 +48,6 @@ A Lacework PagerDuty Alert Channel integration can be imported using a `INT_GUID
 $ terraform import lacework_alert_channel_pagerduty.critical EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework alert-channel list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).
 

--- a/website/docs/r/alert_channel_qradar.html.markdown
+++ b/website/docs/r/alert_channel_qradar.html.markdown
@@ -41,5 +41,5 @@ A Lacework IBM QRadar Alert Channel integration can be imported using a `INT_GUI
 $ terraform import lacework_alert_channel_qradar.example EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework alert-channel list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/alert_channel_service_now.html.markdown
+++ b/website/docs/r/alert_channel_service_now.html.markdown
@@ -43,5 +43,5 @@ A Lacework Service Now Alert Channel integration can be imported using a `INT_GU
 $ terraform import lacework_alert_channel_service_now.ops_critical EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework alert-channel list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/alert_channel_slack.html.markdown
+++ b/website/docs/r/alert_channel_slack.html.markdown
@@ -37,5 +37,5 @@ A Lacework Slack Alert Channel integration can be imported using a `INT_GUID`, e
 $ terraform import lacework_alert_channel_slack.ops_critical EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework alert-channel list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/alert_channel_splunk.html.markdown
+++ b/website/docs/r/alert_channel_splunk.html.markdown
@@ -54,5 +54,5 @@ A Lacework Splunk Alert Channel integration can be imported using a `INT_GUID`, 
 $ terraform import lacework_alert_channel_splunk.ops_critical EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework alert-channel list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/alert_channel_victorops.html.markdown
+++ b/website/docs/r/alert_channel_victorops.html.markdown
@@ -37,5 +37,5 @@ A Lacework VictorOps Alert Channel integration can be imported using a `INT_GUID
 $ terraform import lacework_alert_channel_victorops.example EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework alert-channel list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/alert_channel_webhook.html.markdown
+++ b/website/docs/r/alert_channel_webhook.html.markdown
@@ -39,5 +39,5 @@ A Lacework Webhook Alert Channel integration can be imported using a `INT_GUID`,
 $ terraform import lacework_alert_channel_webhook.ops_critical EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework alert-channel list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/integration_aws_cfg.html.markdown
+++ b/website/docs/r/integration_aws_cfg.html.markdown
@@ -46,5 +46,5 @@ A Lacework AWS Config integration can be imported using a `INT_GUID`, e.g.
 $ terraform import lacework_integration_aws_cfg.account_abc EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework cloud-account list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/integration_aws_ct.html.markdown
+++ b/website/docs/r/integration_aws_ct.html.markdown
@@ -172,5 +172,5 @@ A Lacework AWS CloudTrail integration can be imported using a `INT_GUID`, e.g.
 $ terraform import lacework_integration_aws_ct.account_abc EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework cloud-account list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/integration_aws_eks_audit_log.html.markdown
+++ b/website/docs/r/integration_aws_eks_audit_log.html.markdown
@@ -48,5 +48,5 @@ A Lacework AWS EKS Audit Log integration can be imported using a `INT_GUID`, e.g
 $ terraform import lacework_integration_aws_eks_audit_log.account_abc EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework cloud-account list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/integration_aws_govcloud_cfg.html.markdown
+++ b/website/docs/r/integration_aws_govcloud_cfg.html.markdown
@@ -50,5 +50,5 @@ A Lacework AWS Config integration for AWS GovCloud can be imported using a `INT_
 $ terraform import lacework_integration_aws_govcloud_cfg.example EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework cloud-account list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/integration_aws_govcloud_ct.html.markdown
+++ b/website/docs/r/integration_aws_govcloud_ct.html.markdown
@@ -51,5 +51,5 @@ A Lacework AWS CloudTrail integration for AWS GovCloud can be imported using a `
 $ terraform import lacework_integration_aws_govcloud_ct.example EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework cloud-account list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/integration_azure_al.html.markdown
+++ b/website/docs/r/integration_azure_al.html.markdown
@@ -51,5 +51,5 @@ A Lacework Azure Activity Log integration can be imported using a `INT_GUID`, e.
 $ terraform import lacework_integration_azure_at.account_abc EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework cloud-account list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/integration_azure_cfg.html.markdown
+++ b/website/docs/r/integration_azure_cfg.html.markdown
@@ -48,5 +48,5 @@ A Lacework Azure Config integration can be imported using a `INT_GUID`, e.g.
 $ terraform import lacework_integration_azure_cfg.account_abc EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework cloud-account list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli).

--- a/website/docs/r/integration_docker_hub.html.markdown
+++ b/website/docs/r/integration_docker_hub.html.markdown
@@ -47,5 +47,5 @@ A Lacework Docker Hub container registry integration can be imported using a `IN
 $ terraform import lacework_integration_docker_hub.example EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework container-registry list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/integration_docker_v2.html.markdown
+++ b/website/docs/r/integration_docker_v2.html.markdown
@@ -64,5 +64,5 @@ A Lacework Docker V2 container registry integration can be imported using a `INT
 $ terraform import lacework_integration_docker_v2.jfrog EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework container-registry list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/integration_ecr.html.markdown
+++ b/website/docs/r/integration_ecr.html.markdown
@@ -105,7 +105,7 @@ A Lacework ECR integration can be imported using a `INT_GUID`, e.g.
 $ terraform import lacework_integration_ecr.example EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework container-registry list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).
 
 

--- a/website/docs/r/integration_gar.html.markdown
+++ b/website/docs/r/integration_gar.html.markdown
@@ -167,6 +167,6 @@ A Lacework GAR integration can be imported using a `INT_GUID`, e.g.
 $ terraform import lacework_integration_gar.example EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework container-registry list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).
 

--- a/website/docs/r/integration_gcp_at.html.markdown
+++ b/website/docs/r/integration_gcp_at.html.markdown
@@ -72,5 +72,5 @@ A Lacework GCP Audit Trail integration can be imported using a `INT_GUID`, e.g.
 $ terraform import lacework_integration_gcp_at.account_abc EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework cloud-account list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/integration_gcp_cfg.html.markdown
+++ b/website/docs/r/integration_gcp_cfg.html.markdown
@@ -69,5 +69,5 @@ A Lacework GCP Config integration can be imported using a `INT_GUID`, e.g.
 $ terraform import lacework_integration_gcp_cfg.account_abc EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework cloud-account list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/integration_gcp_gke_audit_log.html.markdown
+++ b/website/docs/r/integration_gcp_gke_audit_log.html.markdown
@@ -57,5 +57,5 @@ A Lacework GCP GKE Audit Log integration can be imported using a `INT_GUID`, e.g
 $ terraform import lacework_integration_gcp_gke_audit_log.account_abc EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework cloud-account list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/integration_gcr.html.markdown
+++ b/website/docs/r/integration_gcr.html.markdown
@@ -103,5 +103,5 @@ A Lacework GCR integration can be imported using a `INT_GUID`, e.g.
 $ terraform import lacework_integration_gcr.example EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework container-registry list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).

--- a/website/docs/r/integration_ghcr.html.markdown
+++ b/website/docs/r/integration_ghcr.html.markdown
@@ -51,5 +51,5 @@ A Lacework Github container registry integration can be imported using a `INT_GU
 $ terraform import lacework_integration_ghcr.example EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
 ```
 -> **Note:** To retrieve the `INT_GUID` from existing integrations in your account, use the
-	Lacework CLI command `lacework integration list`. To install this tool follow
+	Lacework CLI command `lacework container-registry list`. To install this tool follow
 	[this documentation](https://docs.lacework.com/cli/).


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-provider-lacework/blob/main/CONTRIBUTING.md
--->

***Issue***: https://lacework.atlassian.net/browse/ALLY-1269

***Description:***
Replace all usages of deprecated cmd `lacework integration list` with `lacework cloud-account | alert-channel | container-registry list`
