### PR TITLE
test: change alert_profile test to read second element from alerts array

### DIFF
--- a/integration/resource_lacework_alert_profile_test.go
+++ b/integration/resource_lacework_alert_profile_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/lacework/go-sdk/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,11 +32,13 @@ func TestAlertProfileCreate(t *testing.T) {
 	actualExtends := terraform.Output(t, terraformOptions, "extends")
 	actualDescription := terraform.Output(t, terraformOptions, "alert_description")
 
+	alert := getAlert(createProps.Data.Alerts, "LW Configuration GCP Violation Alert")
+
 	assert.Equal(t, "LW_CFG_GCP_DEFAULT_PROFILE", createProps.Data.Extends)
-	assert.Equal(t, "{{_OCCURRENCE}} violation for GCP Resource {{RESOURCE_TYPE}}:{{RESOURCE_ID}} in project {{PROJECT_ID}} region {{RESOURCE_REGION}}", createProps.Data.Alerts[1].Description)
-	assert.Equal(t, "Violation", createProps.Data.Alerts[1].Name)
-	assert.Equal(t, "LW Configuration GCP Violation Alert", createProps.Data.Alerts[1].EventName)
-	assert.Equal(t, "{{_OCCURRENCE}} violation detected in project {{PROJECT_ID}}", createProps.Data.Alerts[1].Subject)
+	assert.Equal(t, "{{_OCCURRENCE}} violation for GCP Resource {{RESOURCE_TYPE}}:{{RESOURCE_ID}} in project {{PROJECT_ID}} region {{RESOURCE_REGION}}", alert.Description)
+	assert.Equal(t, "Violation", alert.Name)
+	assert.Equal(t, "LW Configuration GCP Violation Alert", alert.EventName)
+	assert.Equal(t, "{{_OCCURRENCE}} violation detected in project {{PROJECT_ID}}", alert.Subject)
 
 	assert.Equal(t, "CUSTOM_PROFILE_TERRAFORM_TEST", actualID)
 	assert.Equal(t, "LW_CFG_GCP_DEFAULT_PROFILE", actualExtends)
@@ -53,11 +56,13 @@ func TestAlertProfileCreate(t *testing.T) {
 	actualExtends = terraform.Output(t, terraformOptions, "extends")
 	actualDescription = terraform.Output(t, terraformOptions, "alert_description")
 
+	alert = getAlert(createProps.Data.Alerts, "LW Configuration GCP Violation Alert")
+
 	assert.Equal(t, "LW_CFG_GCP_DEFAULT_PROFILE", updateProps.Data.Extends)
-	assert.Equal(t, "{{_OCCURRENCE}} violation for GCP Resource {{RESOURCE_TYPE}}:{{RESOURCE_ID}} in project {{PROJECT_ID}} region {{RESOURCE_REGION}} Updated", updateProps.Data.Alerts[1].Description)
-	assert.Equal(t, "Violation", updateProps.Data.Alerts[1].Name)
-	assert.Equal(t, "LW Configuration GCP Violation Alert", updateProps.Data.Alerts[1].EventName)
-	assert.Equal(t, "{{_OCCURRENCE}} violation detected in project {{PROJECT_ID}}", updateProps.Data.Alerts[1].Subject)
+	assert.Equal(t, "{{_OCCURRENCE}} violation for GCP Resource {{RESOURCE_TYPE}}:{{RESOURCE_ID}} in project {{PROJECT_ID}} region {{RESOURCE_REGION}} Updated", alert.Description)
+	assert.Equal(t, "Violation", alert.Name)
+	assert.Equal(t, "LW Configuration GCP Violation Alert", alert.EventName)
+	assert.Equal(t, "{{_OCCURRENCE}} violation detected in project {{PROJECT_ID}}", alert.Subject)
 
 	assert.Equal(t, "LW_CFG_GCP_DEFAULT_PROFILE", actualExtends)
 	assert.Equal(t, "{{_OCCURRENCE}} violation for GCP Resource {{RESOURCE_TYPE}}:{{RESOURCE_ID}} in project {{PROJECT_ID}} region {{RESOURCE_REGION}} Updated", actualDescription)
@@ -77,4 +82,13 @@ func TestAlertProfileValidate(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Contains(t, msg, "expected value of name to not start with any of \"LW_\"")
+}
+
+func getAlert(alerts []api.AlertTemplate, name string) (alert api.AlertTemplate) {
+	for _, a := range alerts {
+		if a.EventName == name {
+			alert = a
+		}
+	}
+	return
 }

--- a/integration/resource_lacework_alert_profile_test.go
+++ b/integration/resource_lacework_alert_profile_test.go
@@ -32,10 +32,10 @@ func TestAlertProfileCreate(t *testing.T) {
 	actualDescription := terraform.Output(t, terraformOptions, "alert_description")
 
 	assert.Equal(t, "LW_CFG_GCP_DEFAULT_PROFILE", createProps.Data.Extends)
-	assert.Equal(t, "{{_OCCURRENCE}} violation for GCP Resource {{RESOURCE_TYPE}}:{{RESOURCE_ID}} in project {{PROJECT_ID}} region {{RESOURCE_REGION}}", createProps.Data.Alerts[0].Description)
-	assert.Equal(t, "Violation", createProps.Data.Alerts[0].Name)
-	assert.Equal(t, "LW Configuration GCP Violation Alert", createProps.Data.Alerts[0].EventName)
-	assert.Equal(t, "{{_OCCURRENCE}} violation detected in project {{PROJECT_ID}}", createProps.Data.Alerts[0].Subject)
+	assert.Equal(t, "{{_OCCURRENCE}} violation for GCP Resource {{RESOURCE_TYPE}}:{{RESOURCE_ID}} in project {{PROJECT_ID}} region {{RESOURCE_REGION}}", createProps.Data.Alerts[1].Description)
+	assert.Equal(t, "Violation", createProps.Data.Alerts[1].Name)
+	assert.Equal(t, "LW Configuration GCP Violation Alert", createProps.Data.Alerts[1].EventName)
+	assert.Equal(t, "{{_OCCURRENCE}} violation detected in project {{PROJECT_ID}}", createProps.Data.Alerts[1].Subject)
 
 	assert.Equal(t, "CUSTOM_PROFILE_TERRAFORM_TEST", actualID)
 	assert.Equal(t, "LW_CFG_GCP_DEFAULT_PROFILE", actualExtends)
@@ -54,10 +54,10 @@ func TestAlertProfileCreate(t *testing.T) {
 	actualDescription = terraform.Output(t, terraformOptions, "alert_description")
 
 	assert.Equal(t, "LW_CFG_GCP_DEFAULT_PROFILE", updateProps.Data.Extends)
-	assert.Equal(t, "{{_OCCURRENCE}} violation for GCP Resource {{RESOURCE_TYPE}}:{{RESOURCE_ID}} in project {{PROJECT_ID}} region {{RESOURCE_REGION}} Updated", updateProps.Data.Alerts[0].Description)
-	assert.Equal(t, "Violation", updateProps.Data.Alerts[0].Name)
-	assert.Equal(t, "LW Configuration GCP Violation Alert", updateProps.Data.Alerts[0].EventName)
-	assert.Equal(t, "{{_OCCURRENCE}} violation detected in project {{PROJECT_ID}}", updateProps.Data.Alerts[0].Subject)
+	assert.Equal(t, "{{_OCCURRENCE}} violation for GCP Resource {{RESOURCE_TYPE}}:{{RESOURCE_ID}} in project {{PROJECT_ID}} region {{RESOURCE_REGION}} Updated", updateProps.Data.Alerts[1].Description)
+	assert.Equal(t, "Violation", updateProps.Data.Alerts[1].Name)
+	assert.Equal(t, "LW Configuration GCP Violation Alert", updateProps.Data.Alerts[1].EventName)
+	assert.Equal(t, "{{_OCCURRENCE}} violation detected in project {{PROJECT_ID}}", updateProps.Data.Alerts[1].Subject)
 
 	assert.Equal(t, "LW_CFG_GCP_DEFAULT_PROFILE", actualExtends)
 	assert.Equal(t, "{{_OCCURRENCE}} violation for GCP Resource {{RESOURCE_TYPE}}:{{RESOURCE_ID}} in project {{PROJECT_ID}} region {{RESOURCE_REGION}} Updated", actualDescription)

--- a/integration/resource_lacework_alert_profile_test.go
+++ b/integration/resource_lacework_alert_profile_test.go
@@ -88,7 +88,7 @@ func getAlert(alerts []api.AlertTemplate, name string) api.AlertTemplate {
 	var alert api.AlertTemplate
 	for _, a := range alerts {
 		if a.EventName == name {
-			return alert
+			return a
 		}
 	}
 	return alert

--- a/integration/resource_lacework_alert_profile_test.go
+++ b/integration/resource_lacework_alert_profile_test.go
@@ -56,7 +56,7 @@ func TestAlertProfileCreate(t *testing.T) {
 	actualExtends = terraform.Output(t, terraformOptions, "extends")
 	actualDescription = terraform.Output(t, terraformOptions, "alert_description")
 
-	alert = getAlert(createProps.Data.Alerts, "LW Configuration GCP Violation Alert")
+	alert = getAlert(updateProps.Data.Alerts, "LW Configuration GCP Violation Alert")
 
 	assert.Equal(t, "LW_CFG_GCP_DEFAULT_PROFILE", updateProps.Data.Extends)
 	assert.Equal(t, "{{_OCCURRENCE}} violation for GCP Resource {{RESOURCE_TYPE}}:{{RESOURCE_ID}} in project {{PROJECT_ID}} region {{RESOURCE_REGION}} Updated", alert.Description)
@@ -84,11 +84,12 @@ func TestAlertProfileValidate(t *testing.T) {
 	assert.Contains(t, msg, "expected value of name to not start with any of \"LW_\"")
 }
 
-func getAlert(alerts []api.AlertTemplate, name string) (alert api.AlertTemplate) {
+func getAlert(alerts []api.AlertTemplate, name string) api.AlertTemplate {
+	var alert api.AlertTemplate
 	for _, a := range alerts {
 		if a.EventName == name {
-			alert = a
+			return alert
 		}
 	}
-	return
+	return alert
 }


### PR DESCRIPTION
Signed-off-by: Darren Murray <darren.murray@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-provider-lacework/blob/main/CONTRIBUTING.md
--->


***Description:***
Fix alert profile test. Find alertTemplate assertion from returned alerts by name
