### PR TITLE
fix: all container registry integrations 🐛 

### DIFF
--- a/examples/resource_lacework_integration_docker_v2/main.tf
+++ b/examples/resource_lacework_integration_docker_v2/main.tf
@@ -1,17 +1,27 @@
 provider "lacework" {}
 
 resource "lacework_integration_docker_v2" "example" {
-  name            = "My Docker V2 Registry"
+  name                   = "My Docker V2 Registry"
   non_os_package_support = true
-  registry_domain = "my-dockerv2.jfrog.io"
-  username        = "my-user"
-  password        = "a-secret-password"
-  ssl             = true
-  notifications   = true
-  limit_by_tags   = ["dev*", "*test"]
+  registry_domain        = "my-dockerv2.jfrog.io"
+  username               = "my-user"
+  password               = "a-secret-password"
+  ssl                    = true
+  notifications          = true
+  limit_by_tags          = ["dev*", "*test"]
 
-  limit_by_labels = {
-    key1 = "label1"
-    key2 = "label2"
+  limit_by_label {
+    key   = "key"
+    value = "value"
+  }
+
+  limit_by_label {
+    key   = "key"
+    value = "value2"
+  }
+
+  limit_by_label {
+    key   = "foo"
+    value = "bar"
   }
 }

--- a/examples/resource_lacework_integration_ecr/access_key/main.tf
+++ b/examples/resource_lacework_integration_ecr/access_key/main.tf
@@ -9,9 +9,9 @@ terraform {
 provider "lacework" {}
 
 resource "lacework_integration_ecr" "access_key" {
-  name            = "ECR using Access Keys"
+  name                   = "ECR using Access Keys"
   non_os_package_support = true
-  registry_domain = "YourAWSAccount.dkr.ecr.YourRegion.amazonaws.com"
+  registry_domain        = "YourAWSAccount.dkr.ecr.YourRegion.amazonaws.com"
   credentials {
     access_key_id     = "AWS123abcAccessKeyID"
     secret_access_key = "AWS123abc123abcSecretAccessKey0000000000"
@@ -21,8 +21,13 @@ resource "lacework_integration_ecr" "access_key" {
   limit_by_tags         = ["dev*", "*test"]
   limit_by_repositories = ["my-repo", "other-repo"]
 
-  limit_by_labels = {
-    key1 = "label1"
-    key2 = "label2"
+  limit_by_label {
+    key   = "key1"
+    value = "label1"
+  }
+
+  limit_by_label {
+    key   = "key2"
+    value = "label2"
   }
 }

--- a/examples/resource_lacework_integration_ecr/iam_role/main.tf
+++ b/examples/resource_lacework_integration_ecr/iam_role/main.tf
@@ -17,4 +17,14 @@ resource "lacework_integration_ecr" "iam_role" {
   }
   non_os_package_support = var.non_os_package_support
   limit_num_imgs         = var.num_images
+
+  limit_by_label {
+    key   = "key1"
+    value = "label1"
+  }
+
+  limit_by_label {
+    key   = "key2"
+    value = "label2"
+  }
 }

--- a/examples/resource_lacework_integration_gcr/main.tf
+++ b/examples/resource_lacework_integration_gcr/main.tf
@@ -9,8 +9,8 @@ terraform {
 provider "lacework" {}
 
 resource "lacework_integration_gcr" "example" {
-  name            = var.integration_name
-  registry_domain = "gcr.io"
+  name                   = var.integration_name
+  registry_domain        = "gcr.io"
   non_os_package_support = true
   credentials {
     client_id      = var.client_id
@@ -23,8 +23,19 @@ resource "lacework_integration_gcr" "example" {
   limit_by_tags         = ["dev*", "*test"]
   limit_by_repositories = ["my-repo", "other-repo"]
 
-  limit_by_labels = {
-    foo = "bar"
+  limit_by_label {
+    key   = "key"
+    value = "value"
+  }
+
+  limit_by_label {
+    key   = "key"
+    value = "value2"
+  }
+
+  limit_by_label {
+    key   = "foo"
+    value = "bar"
   }
 }
 
@@ -33,13 +44,13 @@ variable "integration_name" {
   default = "Google Container Registry Example"
 }
 variable "client_id" {
-  type      = string
+  type = string
 }
 variable "client_email" {
-  type      = string
+  type = string
 }
 variable "private_key_id" {
-  type      = string
+  type = string
 }
 variable "private_key" {
   type      = string

--- a/integration/resource_lacework_integration_gcr_test.go
+++ b/integration/resource_lacework_integration_gcr_test.go
@@ -33,7 +33,16 @@ func TestIntegrationGCRCreate(t *testing.T) {
 		create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
 		createData := GetContainerRegisteryGcr(create)
 		assert.Equal(t, "Google Container Registry Example", createData.Data.Name)
-		assert.Equal(t, []map[string]string{{"foo": "bar"}}, createData.Data.Data.LimitByLabel)
+
+		assert.Contains(t, createData.Data.Data.LimitByRep, "my-repo")
+		assert.Contains(t, createData.Data.Data.LimitByRep, "other-repo")
+
+		assert.Contains(t, createData.Data.Data.LimitByTag, "dev*")
+		assert.Contains(t, createData.Data.Data.LimitByTag, "*test")
+
+		assert.Contains(t, createData.Data.Data.LimitByLabel, map[string]string{"key": "value"})
+		assert.Contains(t, createData.Data.Data.LimitByLabel, map[string]string{"key": "value2"})
+		assert.Contains(t, createData.Data.Data.LimitByLabel, map[string]string{"foo": "bar"})
 
 		// Update Google Container Registry
 		terraformOptions.Vars["integration_name"] = "Google Container Registry Updated"
@@ -41,6 +50,15 @@ func TestIntegrationGCRCreate(t *testing.T) {
 		update := terraform.ApplyAndIdempotent(t, terraformOptions)
 		updateData := GetContainerRegisteryGcr(update)
 		assert.Equal(t, "Google Container Registry Updated", updateData.Data.Name)
-		assert.Equal(t, []map[string]string{{"foo": "bar"}}, createData.Data.Data.LimitByLabel)
+
+		assert.Contains(t, createData.Data.Data.LimitByRep, "my-repo")
+		assert.Contains(t, createData.Data.Data.LimitByRep, "other-repo")
+
+		assert.Contains(t, createData.Data.Data.LimitByTag, "dev*")
+		assert.Contains(t, createData.Data.Data.LimitByTag, "*test")
+
+		assert.Contains(t, createData.Data.Data.LimitByLabel, map[string]string{"key": "value"})
+		assert.Contains(t, createData.Data.Data.LimitByLabel, map[string]string{"key": "value2"})
+		assert.Contains(t, createData.Data.Data.LimitByLabel, map[string]string{"foo": "bar"})
 	}
 }

--- a/lacework/casting.go
+++ b/lacework/casting.go
@@ -79,22 +79,6 @@ func castAttributeToArrayOfKeyValueMap(d *schema.ResourceData, attr string) []ma
 	return aMap
 }
 
-// extract an attribute from the provided ResourceData and convert it into a map of strings
-// with string keys
-func castAttributeToArrayKeyMapOfStrings(d *schema.ResourceData, attr string) []map[string]string {
-	if castMap, ok := d.Get(attr).(map[string]interface{}); ok {
-		mapList := make([]map[string]string, 1)
-		stringMap := make(map[string]string)
-		for key, val := range castMap {
-			stringMap[key] = val.(string)
-		}
-		mapList[0] = stringMap
-		return mapList
-	}
-
-	return []map[string]string{}
-}
-
 func castAttributeToArrayOfCustomKeyValueMap(d *schema.ResourceData, attr string, key string, value string) []map[string]string {
 	list := d.Get(attr).(*schema.Set).List()
 	aMap := make([]map[string]string, len(list))

--- a/website/docs/r/integration_docker_hub.html.markdown
+++ b/website/docs/r/integration_docker_hub.html.markdown
@@ -40,7 +40,6 @@ The `limit_by_label` block can be defined multiple times to define multiple labe
 * `key` - (Required) The key of the label.
 * `value` - (Required) The value of the label.
 
-
 ## Import
 
 A Lacework Docker Hub container registry integration can be imported using a `INT_GUID`, e.g.

--- a/website/docs/r/integration_docker_hub.html.markdown
+++ b/website/docs/r/integration_docker_hub.html.markdown
@@ -40,6 +40,24 @@ The `limit_by_label` block can be defined multiple times to define multiple labe
 * `key` - (Required) The key of the label.
 * `value` - (Required) The value of the label.
 
+For example, to limit by the label `key` with values `value` and `value2`, plus the label `key1` with value `value`.
+```hcl
+limit_by_label {
+  key   = "key"
+  value = "value"
+}
+
+limit_by_label {
+  key   = "key"
+  value = "value2"
+}
+
+limit_by_label {
+  key   = "key1"
+  value = "value"
+}
+```
+
 ## Import
 
 A Lacework Docker Hub container registry integration can be imported using a `INT_GUID`, e.g.

--- a/website/docs/r/integration_docker_v2.html.markdown
+++ b/website/docs/r/integration_docker_v2.html.markdown
@@ -50,9 +50,13 @@ The following arguments are supported:
 * `ssl` - (Optional) Enable or disable SSL communication. Defaults to `false`.
 * `notifications` - (Optional) Subscribe to registry notifications. Defaults to `false`.
 * `enabled` - (Optional) The state of the external integration. Defaults to `true`.
-* `limit_by_tags` - (Optional) A list of image tags to limit the assessment of images with matching tags. If you specify `limit_by_tags` and `limit_by_labels` limits, they function as an `AND`.
-* `limit_by_labels` - (Optional) A key based map of labels to limit the assessment of images with matching `key:value` labels. If you specify `limit_by_tags` and `limit_by_labels` limits, they function as an `AND`.
 * `non_os_package_support` - (Optional) Enable [program language scanning](https://docs.lacework.com/container-image-support#language-libraries-support). Defaults to `true`.
+* `limit_by_tags` - (Optional) A list of image tags to limit the assessment of images with matching tags. If you specify `limit_by_tags` and `limit_by_labels` limits, they function as an `AND`.
+* `limit_by_label` - (Optional) A list of key/value labels to limit the assessment of images. If you specify `limit_by_tags` and `limit_by_label` limits, they function as an `AND`.
+
+The `limit_by_label` block can be defined multiple times to define multiple label limits, it supports:
+* `key` - (Required) The key of the label.
+* `value` - (Required) The value of the label.
 
 ## Import
 

--- a/website/docs/r/integration_docker_v2.html.markdown
+++ b/website/docs/r/integration_docker_v2.html.markdown
@@ -58,6 +58,24 @@ The `limit_by_label` block can be defined multiple times to define multiple labe
 * `key` - (Required) The key of the label.
 * `value` - (Required) The value of the label.
 
+For example, to limit by the label `key` with values `value` and `value2`, plus the label `key1` with value `value`.
+```hcl
+limit_by_label {
+  key   = "key"
+  value = "value"
+}
+
+limit_by_label {
+  key   = "key"
+  value = "value2"
+}
+
+limit_by_label {
+  key   = "key1"
+  value = "value"
+}
+```
+
 ## Import
 
 A Lacework Docker V2 container registry integration can be imported using a `INT_GUID`, e.g.

--- a/website/docs/r/integration_ecr.html.markdown
+++ b/website/docs/r/integration_ecr.html.markdown
@@ -78,12 +78,16 @@ The following arguments are supported:
 * `name` - (Required) The ECR integration name.
 * `registry_domain` - (Required) The Amazon Container Registry (ECR) domain in the format `YourAWSAccount.dkr.ecr.YourRegion.amazonaws.com`, where `YourAWSAcount` is the AWS account number for the AWS IAM user that has a role with permissions to access the ECR and `YourRegion` is your AWS region such as `us-west-2`.
 * `credentials` - (Required) The credentials needed by the integration. See [Credentials](#credentials) below for details.
+* `non_os_package_support` - (Optional) Enable [program language scanning](https://docs.lacework.com/container-image-support#language-libraries-support). Defaults to `true`.
 * `limit_num_imgs` - (Optional) The maximum number of newest container images to assess per repository. Must be one of `5`, `10`, or `15`. Defaults to `5`.
 * `enabled` - (Optional) The state of the external integration. Defaults to `true`.
 * `limit_by_tags` - (Optional) A list of image tags to limit the assessment of images with matching tags. If you specify `limit_by_tags` and `limit_by_labels` limits, they function as an `AND`.
-* `limit_by_labels` - (Optional) A key based map of labels to limit the assessment of images with matching `key:value` labels. If you specify `limit_by_tags` and `limit_by_labels` limits, they function as an `AND`.
 * `limit_by_repositories` - (Optional) A list of repositories to assess.
-* `non_os_package_support` - (Optional) Enable [program language scanning](https://docs.lacework.com/container-image-support#language-libraries-support). Defaults to `true`.
+* `limit_by_label` - (Optional) A list of key/value labels to limit the assessment of images. If you specify `limit_by_tags` and `limit_by_label` limits, they function as an `AND`.
+
+The `limit_by_label` block can be defined multiple times to define multiple label limits, it supports:
+* `key` - (Required) The key of the label.
+* `value` - (Required) The value of the label.
 
 ### Credentials
 

--- a/website/docs/r/integration_ecr.html.markdown
+++ b/website/docs/r/integration_ecr.html.markdown
@@ -89,6 +89,24 @@ The `limit_by_label` block can be defined multiple times to define multiple labe
 * `key` - (Required) The key of the label.
 * `value` - (Required) The value of the label.
 
+For example, to limit by the label `key` with values `value` and `value2`, plus the label `key1` with value `value`.
+```hcl
+limit_by_label {
+  key   = "key"
+  value = "value"
+}
+
+limit_by_label {
+  key   = "key"
+  value = "value2"
+}
+
+limit_by_label {
+  key   = "key1"
+  value = "value"
+}
+```
+
 ### Credentials
 
 `credentials` supports the combination of the following arguments.

--- a/website/docs/r/integration_gar.html.markdown
+++ b/website/docs/r/integration_gar.html.markdown
@@ -43,28 +43,6 @@ module "gar" {
 
 To see the list of inputs, outputs and dependencies, visit the [Terraform registry page of this module](https://registry.terraform.io/modules/lacework/gar/gcp/latest).
 
-## Example Loading Credentials from Local File
-
-Alternatively, this example shows how to load a [service account key created](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys)
-using the Cloud Console or the `gcloud` command-line tool located on a local file on disk:
-
-```hcl
-locals {
-  gar_credentials = jsondecode(file("/path/to/creds.json"))
-}
-
-resource "lacework_integration_gar" "example" {
-  name            = "GAR Example"
-  registry_domain = "us-west1-docker.pkg.dev"
-  credentials {
-    client_id      = local.gar.client_id
-    client_email   = local.gar.client_email
-    private_key_id = local.gar.private_key_id
-    private_key    = local.gar.private_key
-  }
-}
-```
-
 ## Example Using Limits
 
 ```hcl
@@ -116,6 +94,24 @@ The following arguments are supported:
 The `limit_by_label` block can be defined multiple times to define multiple label limits, it supports:
 * `key` - (Required) The key of the label.
 * `value` - (Required) The value of the label.
+
+For example, to limit by the label `key` with values `value` and `value2`, plus the label `key1` with value `value`.
+```hcl
+limit_by_label {
+  key   = "key"
+  value = "value"
+}
+
+limit_by_label {
+  key   = "key"
+  value = "value2"
+}
+
+limit_by_label {
+  key   = "key1"
+  value = "value"
+}
+```
 
 ### Credentials
 

--- a/website/docs/r/integration_gcr.html.markdown
+++ b/website/docs/r/integration_gcr.html.markdown
@@ -81,6 +81,24 @@ The `limit_by_label` block can be defined multiple times to define multiple labe
 * `key` - (Required) The key of the label.
 * `value` - (Required) The value of the label.
 
+For example, to limit by the label `key` with values `value` and `value2`, plus the label `key1` with value `value`.
+```hcl
+limit_by_label {
+  key   = "key"
+  value = "value"
+}
+
+limit_by_label {
+  key   = "key"
+  value = "value2"
+}
+
+limit_by_label {
+  key   = "key1"
+  value = "value"
+}
+```
+
 ### Credentials
 
 `credentials` supports the following arguments:

--- a/website/docs/r/integration_gcr.html.markdown
+++ b/website/docs/r/integration_gcr.html.markdown
@@ -51,18 +51,14 @@ Alternatively, this example shows how to load a [service account key created](ht
 using the Cloud Console or the `gcloud` command-line tool located on a local file on disk:
 
 ```hcl
-locals {
-  gcr_credentials = jsondecode(file("/path/to/creds.json"))
-}
-
 resource "lacework_integration_gcr" "example" {
   name            = "GRC Example"
   registry_domain = "gcr.io"
   credentials {
-    client_id      = local.gcr_credentials.client_id
-    client_email   = local.gcr_credentials.client_email
-    private_key_id = local.gcr_credentials.private_key_id
-    private_key    = local.gcr_credentials.private_key
+    client_id      = "123456789012345678900"
+    client_email   = "email@abc-project-name.iam.gserviceaccount.com"
+    private_key_id = "1234abcd1234abcd1234abcd1234abcd1234abcd"
+    private_key    = "-----BEGIN PRIVATE KEY-----\n ... -----END PRIVATE KEY-----\n"
   }
 }
 ```
@@ -76,10 +72,14 @@ The following arguments are supported:
 * `credentials` - (Required) The credentials needed by the integration. See [Credentials](#credentials) below for details.
 * `limit_num_imgs` - (Optional) The maximum number of newest container images to assess per repository. Must be one of `5`, `10`, or `15`. Defaults to `5`.
 * `enabled` - (Optional) The state of the external integration. Defaults to `true`.
-* `limit_by_tags` - (Optional) A list of image tags to limit the assessment of images with matching tags. If you specify `limit_by_tags` and `limit_by_labels` limits, they function as an `AND`.
-* `limit_by_labels` - (Optional) A key based map of labels to limit the assessment of images with matching `key:value` labels. If you specify `limit_by_tags` and `limit_by_labels` limits, they function as an `AND`.
-* `limit_by_repositories` - (Optional) A list of repositories to assess.
 * `non_os_package_support` - (Optional) Enable [program language scanning](https://docs.lacework.com/container-image-support#language-libraries-support). Defaults to `true`.
+* `limit_by_tags` - (Optional) A list of image tags to limit the assessment of images with matching tags. If you specify `limit_by_tags` and `limit_by_labels` limits, they function as an `AND`.
+* `limit_by_repositories` - (Optional) A list of repositories to assess.
+* `limit_by_label` - (Optional) A list of key/value labels to limit the assessment of images. If you specify `limit_by_tags` and `limit_by_label` limits, they function as an `AND`.
+
+The `limit_by_label` block can be defined multiple times to define multiple label limits, it supports:
+* `key` - (Required) The key of the label.
+* `value` - (Required) The value of the label.
 
 ### Credentials
 

--- a/website/docs/r/integration_ghcr.html.markdown
+++ b/website/docs/r/integration_ghcr.html.markdown
@@ -43,6 +43,24 @@ The `limit_by_label` block can be defined multiple times to define multiple labe
 * `key` - (Required) The key of the label.
 * `value` - (Required) The value of the label.
 
+For example, to limit by the label `key` with values `value` and `value2`, plus the label `key1` with value `value`.
+```hcl
+limit_by_label {
+  key   = "key"
+  value = "value"
+}
+
+limit_by_label {
+  key   = "key"
+  value = "value2"
+}
+
+limit_by_label {
+  key   = "key1"
+  value = "value"
+}
+```
+
 ## Import
 
 A Lacework Github container registry integration can be imported using a `INT_GUID`, e.g.


### PR DESCRIPTION
***Issue***: https://lacework.atlassian.net/browse/LINK-1089

***Description:***
We are replacing the argument `limit_by_labels` in favor of `limit_by_label`

Why? Because users can set many labels with the same key. For example,
to limit by the label `key` with values `value` and `value2`, plus the label `key1` with value `value`.
```hcl
limit_by_label {
  key   = "key"
  value = "value"
}
limit_by_label {
  key   = "key"
  value = "value2"
}
limit_by_label {
  key   = "key1"
  value = "value"
}
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>