### PR TITLE
ci: fix new policy tag restrictions

### DIFF
--- a/examples/resource_lacework_policy/main.tf
+++ b/examples/resource_lacework_policy/main.tf
@@ -60,8 +60,8 @@ variable "policy_id_suffix" {
 }
 
 variable "tags" {
-  type = list(string)
-  default = ["domain:AWS", "custom"]
+  type    = list(string)
+  default = ["cloud_AWS", "custom"]
 }
 
 output "title" {

--- a/website/docs/r/policy.html.markdown
+++ b/website/docs/r/policy.html.markdown
@@ -50,7 +50,7 @@ resource "lacework_policy" "example" {
   severity    = "High"
   type        = "Violation"
   evaluation  = "Hourly"
-  tags        = ["domain:AWS", "custom"]
+  tags        = ["cloud_AWS", "custom"]
   enabled     = false
 
   alerting {


### PR DESCRIPTION

***Issue***: N/A - Saw it on our CI pipeline

***Description:***
CI is failing with:
```
│ Error:                                                                                                                                                                                                                                           
│   [POST] https://customerdemo.lacework.net/api/v2/Policies                                                                                                                                                                                       
│   [400] [Error: tag key: domain is reserved, Error: tag key: subdomain is reserved]                                                                                                                                                              
│                                                                                                                                                                                                                                                  
│   with lacework_policy.example,                                                                                                                                                                                                                  
│   on main.tf line 9, in resource "lacework_policy" "example":                                                                                                                                                                                    
│    9: resource "lacework_policy" "example" {                                                                                                                                                                                                     
│                                                                                                                                                                                                                                                  
╵}    
```
***Additional Info:***
<img src="https://media2.giphy.com/media/l0MYw0DsFJc0kU0Jq/giphy.gif"/>