### PR TITLE
fix: alert-rule 'event categories' drift

### DIFF
--- a/examples/resource_lacework_alert_rule/main.tf
+++ b/examples/resource_lacework_alert_rule/main.tf
@@ -37,7 +37,7 @@ variable "description" {
 
 variable "channels" {
   type    = list(string)
-  default = ["TECHALLY_AB90D4E77C93A9DE0DF6B22B9B06B9934645D6027C9D350"]
+  default = ["TECHALLY_013F08F1B3FA97E7D54463DECAEEACF9AEA3AEACF863F76"]
 }
 
 variable "severities" {
@@ -47,7 +47,7 @@ variable "severities" {
 
 variable "event_categories" {
   type    = list(string)
-  default = ["Compliance"]
+  default = ["Compliance", "Platform", "User", "Cloud"]
 }
 
 output "name" {

--- a/integration/resource_lacework_alert_rule_test.go
+++ b/integration/resource_lacework_alert_rule_test.go
@@ -16,8 +16,7 @@ import (
 //
 // It uses the go-sdk to verify the created alert rule,
 // applies an update and destroys it
-// nolint
-func _TestAlertRuleCreate(t *testing.T) {
+func TestAlertRuleCreate(t *testing.T) {
 	name := fmt.Sprintf("Alert Rule - %s", time.Now())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_rule",
@@ -25,7 +24,7 @@ func _TestAlertRuleCreate(t *testing.T) {
 		Vars: map[string]interface{}{
 			"name":                name,
 			"description":         "Alert Rule created by Terraform",
-			"channels":            []string{"TECHALLY_AB90D4E77C93A9DE0DF6B22B9B06B9934645D6027C9D350"},
+			"channels":            []string{"TECHALLY_013F08F1B3FA97E7D54463DECAEEACF9AEA3AEACF863F76"},
 			"severities":          []string{"Critical"},
 			"event_categories":    []string{"Compliance"},
 			"resource_group_name": fmt.Sprintf("Used for Alert Rule Test - %s", time.Now()),
@@ -46,14 +45,14 @@ func _TestAlertRuleCreate(t *testing.T) {
 	actualResourceGroupID := terraform.Output(t, terraformOptions, "resource_group_id")
 
 	assert.Equal(t, "Alert Rule created by Terraform", createProps.Data.Filter.Description)
-	assert.Equal(t, []string{"TECHALLY_AB90D4E77C93A9DE0DF6B22B9B06B9934645D6027C9D350"}, createProps.Data.Channels)
+	assert.Equal(t, []string{"TECHALLY_013F08F1B3FA97E7D54463DECAEEACF9AEA3AEACF863F76"}, createProps.Data.Channels)
 	assert.Equal(t, []string{"Critical"}, api.NewAlertRuleSeveritiesFromIntSlice(createProps.Data.Filter.Severity).ToStringSlice())
 	assert.Equal(t, []string{actualResourceGroupID}, createProps.Data.Filter.ResourceGroups)
 	assert.Equal(t, []string{"Compliance"}, createProps.Data.Filter.EventCategories)
 
 	assert.Equal(t, name, actualName)
 	assert.Equal(t, "Alert Rule created by Terraform", actualDescription)
-	assert.Equal(t, "[TECHALLY_AB90D4E77C93A9DE0DF6B22B9B06B9934645D6027C9D350]", actualChannels)
+	assert.Equal(t, "[TECHALLY_013F08F1B3FA97E7D54463DECAEEACF9AEA3AEACF863F76]", actualChannels)
 	assert.Equal(t, string("[Critical]"), actualSeverities)
 	assert.Equal(t, "[Compliance]", actualEventCategories)
 
@@ -61,8 +60,8 @@ func _TestAlertRuleCreate(t *testing.T) {
 	terraformOptions.Vars = map[string]interface{}{
 		"name":        name,
 		"description": "Updated Alert Rule created by Terraform",
-		"channels": []string{"TECHALLY_AB90D4E77C93A9DE0DF6B22B9B06B9934645D6027C9D350",
-			"TECHALLY_5AB90986035F116604A26E1634340AC4FEDD1722A4D6A53"},
+		"channels": []string{"TECHALLY_01BA9DCAF34B654254D6BF92E5C24023951C3F812B07527",
+			"TECHALLY_013F08F1B3FA97E7D54463DECAEEACF9AEA3AEACF863F76"},
 		"severities":          []string{"High", "Medium"},
 		"event_categories":    []string{"Compliance", "User", "Platform"},
 		"resource_group_name": fmt.Sprintf("Used for Alert Rule Test - %s", time.Now()),
@@ -77,21 +76,19 @@ func _TestAlertRuleCreate(t *testing.T) {
 	actualResourceGroupID = terraform.Output(t, terraformOptions, "resource_group_id")
 
 	assert.Equal(t, "Updated Alert Rule created by Terraform", updateProps.Data.Filter.Description)
-	assert.Contains(t, updateProps.Data.Channels, "TECHALLY_AB90D4E77C93A9DE0DF6B22B9B06B9934645D6027C9D350")
-	assert.Contains(t, updateProps.Data.Channels, "TECHALLY_5AB90986035F116604A26E1634340AC4FEDD1722A4D6A53")
+	assert.Contains(t, updateProps.Data.Channels, "TECHALLY_01BA9DCAF34B654254D6BF92E5C24023951C3F812B07527")
+	assert.Contains(t, updateProps.Data.Channels, "TECHALLY_013F08F1B3FA97E7D54463DECAEEACF9AEA3AEACF863F76")
 	assert.Equal(t, []string{"High", "Medium"}, api.NewAlertRuleSeveritiesFromIntSlice(updateProps.Data.Filter.Severity).ToStringSlice())
 	assert.Equal(t, []string{actualResourceGroupID}, updateProps.Data.Filter.ResourceGroups)
-	assert.Equal(t, []string{"Compliance", "User", "Platform"}, updateProps.Data.Filter.EventCategories)
-
+	assert.ElementsMatch(t, []string{"Compliance", "User", "Platform"}, updateProps.Data.Filter.EventCategories)
 	assert.Equal(t, "Updated Alert Rule created by Terraform", actualDescription)
-	assert.Equal(t, "[TECHALLY_5AB90986035F116604A26E1634340AC4FEDD1722A4D6A53 TECHALLY_AB90D4E77C93A9DE0DF6B22B9B06B9934645D6027C9D350]",
+	assert.Equal(t, "[TECHALLY_013F08F1B3FA97E7D54463DECAEEACF9AEA3AEACF863F76 TECHALLY_01BA9DCAF34B654254D6BF92E5C24023951C3F812B07527]",
 		actualChannels)
 	assert.Equal(t, "[High Medium]", actualSeverities)
-	assert.Equal(t, "[Compliance User Platform]", actualEventCategories)
+	assert.Equal(t, "[Compliance Platform User]", actualEventCategories)
 }
 
-// nolint
-func _TestAlertRuleSeverities(t *testing.T) {
+func TestAlertRuleSeverities(t *testing.T) {
 	name := fmt.Sprintf("Alert Rule - %s", time.Now())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_rule",
@@ -134,8 +131,7 @@ func _TestAlertRuleSeverities(t *testing.T) {
 	}
 }
 
-// nolint
-func _TestAlertRuleCategories(t *testing.T) {
+func TestAlertRuleCategories(t *testing.T) {
 	name := fmt.Sprintf("Alert Rule - %s", time.Now())
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_rule",
@@ -154,8 +150,8 @@ func _TestAlertRuleCategories(t *testing.T) {
 
 	actualCategories := terraform.Output(t, terraformOptions, "event_categories")
 
-	assert.Equal(t, []string{"Compliance", "App", "Cloud", "File", "Machine", "User", "Platform", "K8sActivity"}, createProps.Data.Filter.EventCategories)
-	assert.Equal(t, "[Compliance App Cloud File Machine User Platform K8sActivity]", actualCategories)
+	assert.ElementsMatch(t, []string{"Compliance", "App", "Cloud", "File", "Machine", "User", "Platform", "K8sActivity"}, createProps.Data.Filter.EventCategories)
+	assert.Equal(t, "[App Cloud Compliance File K8sActivity Machine Platform User]", actualCategories)
 
 	invalidOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/resource_lacework_alert_rule",

--- a/lacework/resource_lacework_alert_rule.go
+++ b/lacework/resource_lacework_alert_rule.go
@@ -87,7 +87,7 @@ func resourceLaceworkAlertRule() *schema.Resource {
 				},
 			},
 			"event_categories": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Description: "List of event categories for the alert rule. Valid categories are: " +
 					"Compliance, App, Cloud, File, Machine, User, Platform, K8sActivity",
@@ -137,15 +137,16 @@ func resourceLaceworkAlertRuleCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	var (
-		lacework       = meta.(*api.Client)
-		resourceGroups = d.Get("resource_groups").(*schema.Set).List()
-		severities     = api.NewAlertRuleSeverities(castAttributeToStringSlice(d, "severities"))
-		alertRule      = api.NewAlertRule(d.Get("name").(string),
+		lacework        = meta.(*api.Client)
+		resourceGroups  = d.Get("resource_groups").(*schema.Set).List()
+		eventCategories = d.Get("event_categories").(*schema.Set).List()
+		severities      = api.NewAlertRuleSeverities(castAttributeToStringSlice(d, "severities"))
+		alertRule       = api.NewAlertRule(d.Get("name").(string),
 			api.AlertRuleConfig{
 				Description:     d.Get("description").(string),
 				Channels:        castStringSlice(alertChannels),
 				Severities:      severities,
-				EventCategories: castAttributeToStringSlice(d, "event_categories"),
+				EventCategories: castStringSlice(eventCategories),
 				ResourceGroups:  castStringSlice(resourceGroups),
 			},
 		)
@@ -209,15 +210,16 @@ func resourceLaceworkAlertRuleUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	var (
-		lacework       = meta.(*api.Client)
-		resourceGroups = d.Get("resource_groups").(*schema.Set).List()
-		severities     = api.NewAlertRuleSeverities(castAttributeToStringSlice(d, "severities"))
-		alertRule      = api.NewAlertRule(d.Get("name").(string),
+		lacework        = meta.(*api.Client)
+		resourceGroups  = d.Get("resource_groups").(*schema.Set).List()
+		eventCategories = d.Get("event_categories").(*schema.Set).List()
+		severities      = api.NewAlertRuleSeverities(castAttributeToStringSlice(d, "severities"))
+		alertRule       = api.NewAlertRule(d.Get("name").(string),
 			api.AlertRuleConfig{
 				Description:     d.Get("description").(string),
 				Channels:        castStringSlice(alertChannels),
 				Severities:      severities,
-				EventCategories: castAttributeToStringSlice(d, "event_categories"),
+				EventCategories: castStringSlice(eventCategories),
 				ResourceGroups:  castStringSlice(resourceGroups),
 			},
 		)


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-provider-lacework/blob/main/CONTRIBUTING.md
--->

***Issue***: https://lacework.atlassian.net/browse/GROW-1373

***Description:***

- Change `event_categories` to TypeSet so Terraform will ignore the ordering in a diff.

- Reenable AlertRule tests `TestAlertRuleCreate`