### PR TITLE
docs: add 'enabled' to agent_access_token doc

### DIFF
--- a/website/docs/r/agent_access_token.html.markdown
+++ b/website/docs/r/agent_access_token.html.markdown
@@ -39,6 +39,7 @@ The following arguments are supported:
 
 * `name` - (Required) The agent access token name.
 * `description` - (Optional) The agent access token description.
+* `enabled` - (Optional) The state of the integration. Defaults to `true`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-provider-lacework/blob/main/CONTRIBUTING.md
--->

***Issue***: Include link to the Jira/Github Issue
https://lacework.atlassian.net/jira/software/projects/GROW/boards/58?selectedIssue=GROW-1434

***Description:***
Add missing field `enabled` from `agent_access_token` resource
