### PR TITLE
docs(website): add multivolume and stopped instance arguments

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -462,8 +462,6 @@ github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
-github.com/lacework/go-sdk v1.23.1-0.20230622154455-670811cdac84 h1:oxZmsM/NQr5lingCrypvxadHfMtfQyGNs7S/8MsKfS8=
-github.com/lacework/go-sdk v1.23.1-0.20230622154455-670811cdac84/go.mod h1:fof2gHpOJI8EM9f6oH1ovP3ly2kDcEKciZJqjtCKMEs=
 github.com/lacework/go-sdk v1.24.0 h1:egMfHltwZncIaSiwcG0OAH28YKTLYbTt+2VD+1G06mk=
 github.com/lacework/go-sdk v1.24.0/go.mod h1:fof2gHpOJI8EM9f6oH1ovP3ly2kDcEKciZJqjtCKMEs=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
@@ -511,7 +509,6 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=

--- a/website/docs/r/integration_aws_agentless_scanning.html.markdown
+++ b/website/docs/r/integration_aws_agentless_scanning.html.markdown
@@ -37,6 +37,8 @@ The following arguments are supported:
 * `query_text` - (Optional) The lql query.
 * `scan_containers` - (Optional) Whether to includes scanning for containers.
 * `scan_host_vulnerabilities` - (Optional) Whether to includes scanning for host vulnerabilities.
+* `scan_multi_volume` - (Optional) Whether to scan secondary volumes (`true`) or only root volumes (`false`). Defaults to `false`
+* `scan_stopped_instances` - (Optional) Whether to scan stopped instances (`true`). Defaults to `true`
 * `account_id` - (Optional) The aws account id.
 * `bucket_arn` - (Optional) The bucket arn.
 * `credentials` - (Optional) The credentials needed by the integration. See [Credentials](#credentials) below for details.

--- a/website/docs/r/integration_aws_org_agentless_scanning.html.markdown
+++ b/website/docs/r/integration_aws_org_agentless_scanning.html.markdown
@@ -43,6 +43,8 @@ The following arguments are supported:
 * `query_text` - (Optional) The LQL query.
 * `scan_containers` - (Optional) Whether to includes scanning for containers.
 * `scan_host_vulnerabilities` - (Optional) Whether to includes scanning for host vulnerabilities.
+* `scan_multi_volume` - (Optional) Whether to scan secondary volumes (`true`) or only root volumes (`false`). Defaults to `false`
+* `scan_stopped_instances` - (Optional) Whether to scan stopped instances (`true`). Defaults to `true`
 * `account_id` - (Optional) The AWS account ID.
 * `bucket_arn` - (Optional) The bucket ARN.
 * `scanning_account` - (Required) The scanning AWS account ID.

--- a/website/docs/r/integration_gcp_agentless_scanning.html.markdown
+++ b/website/docs/r/integration_gcp_agentless_scanning.html.markdown
@@ -43,6 +43,8 @@ The following arguments are supported:
 * `scan_containers` - (Optional) Whether to includes scanning for containers. Defaults to `true`
 * `scan_host_vulnerabilities` - (Optional) Whether to include scanning for host vulnerabilities. Defaults to `true`
 * `credentials` - (Optional) The credentials needed by the integration. See [Credentials](#credentials) below for details.
+* `scan_multi_volume` - (Optional) Whether to scan secondary volumes (`true`) or only root volumes (`false`). Defaults to `false`
+* `scan_stopped_instances` - (Optional) Whether to scan stopped instances (`true`). Defaults to `true`
 * `enabled` - (Optional) The state of the external integration. Defaults to `true`.
 * `retries` - (Optional) The number of attempts to create the external integration. Defaults to `5`.
 


### PR DESCRIPTION
***Issue***: https://lacework.atlassian.net/browse/RAIN-54831 

***Description:***
This is a follow up to https://github.com/lacework/terraform-provider-lacework/pull/484#pullrequestreview-1515286361 to add documentation updates added in that PR.

***Additional Info:***
I've also committed the result of `make go-vendor` in e84fff5f3c2456bdc29d2c8fcc8e222c7bc3c525 in response to a slack sidebar: https://lacework.slack.com/archives/C03H3863SQG/p1688587897383779