### PR TITLE
feat: add new lacework_managed_policies resource

### DIFF
--- a/examples/resource_lacework_managed_policies/main.tf
+++ b/examples/resource_lacework_managed_policies/main.tf
@@ -1,0 +1,54 @@
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+resource "lacework_managed_policies" "example" {
+  policy {
+    id       = var.id_1
+    enabled  = var.enabled_1
+    severity = var.severity_1
+  }
+  policy {
+    id       = var.id_2
+    enabled  = var.enabled_2
+    severity = var.severity_2
+  }
+}
+
+variable "id_1" {
+  type    = string
+  default = "lacework-global-1"
+}
+
+variable "enabled_1" {
+  type    = bool
+  default = true
+}
+
+variable "severity_1" {
+  type    = string
+  default = null
+}
+
+variable "id_2" {
+  type    = string
+  default = "lacework-global-2"
+}
+
+variable "enabled_2" {
+  type    = bool
+  default = true
+}
+
+variable "severity_2" {
+  type    = string
+  default = null
+}
+
+output "policy" {
+  value = lacework_managed_policies.example.policy
+}

--- a/examples/resource_lacework_managed_policies/main.tf
+++ b/examples/resource_lacework_managed_policies/main.tf
@@ -31,7 +31,6 @@ variable "enabled_1" {
 
 variable "severity_1" {
   type    = string
-  default = null
 }
 
 variable "id_2" {
@@ -46,7 +45,6 @@ variable "enabled_2" {
 
 variable "severity_2" {
   type    = string
-  default = null
 }
 
 output "policy" {

--- a/examples/resource_lacework_managed_policies/main.tf
+++ b/examples/resource_lacework_managed_policies/main.tf
@@ -26,7 +26,6 @@ variable "id_1" {
 
 variable "enabled_1" {
   type    = bool
-  default = true
 }
 
 variable "severity_1" {
@@ -40,7 +39,6 @@ variable "id_2" {
 
 variable "enabled_2" {
   type    = bool
-  default = true
 }
 
 variable "severity_2" {

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -438,6 +438,14 @@ func GetPolicyProps(result string) api.PolicyResponse {
 	return resp
 }
 
+func GetPolicyPropsById(id string) api.PolicyResponse {
+	resp, err := LwClient.V2.Policy.Get(id)
+	if err != nil {
+		log.Fatalf("Unable to retrieve policy with id: %s", id)
+	}
+	return resp
+}
+
 func GetPolicyExceptionProps(result string, policyID string) (resp api.PolicyExceptionResponse) {
 	id := GetSpecificIDFromTerraResults(1, result)
 	err := LwClient.V2.Policy.Exceptions.Get(policyID, id, &resp)

--- a/integration/resource_lacework_managed_policies_test.go
+++ b/integration/resource_lacework_managed_policies_test.go
@@ -1,0 +1,113 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestManagedPolicies applies integration terraform:
+// => '../examples/resource_lacework_managed_policies'
+//
+// It uses the go-sdk to verify that the lacework managed policies can be updated correctly.
+// nolint
+func TestManagedPolicies(t *testing.T) {
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/resource_lacework_managed_policies",
+		EnvVars:      tokenEnvVar,
+		Vars: map[string]interface{}{
+			"id_1":       "lacework-global-1",
+			"enabled_1":  false,
+			"severity_1": "High",
+			"id_2":       "lacework-global-2",
+			"enabled_2":  false,
+			"severity_2": "Critical",
+		},
+	})
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+
+	policies := terraform.Output(t, terraformOptions, "policy")
+	assert.Equal(t, "[map[enabled:false id:lacework-global-1 severity:high] map[enabled:false id:lacework-global-2 severity:critical]]", policies)
+
+	policy1Props := GetPolicyPropsById("lacework-global-1")
+	assert.False(t, policy1Props.Data.Enabled)
+	assert.Equal(t, "high", policy1Props.Data.Severity)
+
+	policy2Props := GetPolicyPropsById("lacework-global-2")
+	assert.False(t, policy2Props.Data.Enabled)
+	assert.Equal(t, "critical", policy2Props.Data.Severity)
+
+	// Update managed policies
+	terraformOptions.Vars = map[string]interface{}{
+		"id_1":       "lacework-global-1",
+		"enabled_1":  true,
+		"severity_1": "Low",
+		"id_2":       "lacework-global-2",
+		"enabled_2":  true,
+		"severity_2": "Medium",
+	}
+
+	terraform.ApplyAndIdempotent(t, terraformOptions)
+	updatePolicy1Props := GetPolicyPropsById("lacework-global-1")
+	assert.True(t, updatePolicy1Props.Data.Enabled)
+	assert.Equal(t, "low", updatePolicy1Props.Data.Severity)
+
+	updatePolicy2Props := GetPolicyPropsById("lacework-global-2")
+	assert.True(t, updatePolicy2Props.Data.Enabled)
+	assert.Equal(t, "medium", updatePolicy2Props.Data.Severity)
+}
+
+// TestManagedPoliciesWithDuplicateIDs applies integration terraform:
+// => '../examples/resource_lacework_managed_policies'
+//
+// It uses the go-sdk to verify that the lacework managed policies can not have duplicate policy IDs.
+// nolint
+func TestManagedPoliciesWithDuplicateIDs(t *testing.T) {
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/resource_lacework_managed_policies",
+		EnvVars:      tokenEnvVar,
+		Vars: map[string]interface{}{
+			"id_1":       "lacework-global-1",
+			"enabled_1":  false,
+			"severity_1": "High",
+			"id_2":       "lacework-global-1",
+			"enabled_2":  false,
+			"severity_2": "Critical",
+		},
+	})
+	defer terraform.Destroy(t, terraformOptions)
+
+	_, err := terraform.InitAndApplyE(t, terraformOptions)
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "Unable to update duplicate policy ID")
+}
+
+// TestManagedPoliciesWithCustomIDs applies integration terraform:
+// => '../examples/resource_lacework_managed_policies'
+//
+// It uses the go-sdk to verify if the lacework managed policies can not have custom policy IDs.
+// nolint
+func TestManagedPoliciesWithCustomIDs(t *testing.T) {
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/resource_lacework_managed_policies",
+		EnvVars:      tokenEnvVar,
+		Vars: map[string]interface{}{
+			"id_1":       "lacework-custom-1",
+			"enabled_1":  false,
+			"severity_1": "High",
+			"id_2":       "lacework-custom-2",
+			"enabled_2":  false,
+			"severity_2": "Critical",
+		},
+	})
+	defer terraform.Destroy(t, terraformOptions)
+
+	_, err := terraform.InitAndApplyE(t, terraformOptions)
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "Unable to update custom policy ID")
+}

--- a/lacework/provider.go
+++ b/lacework/provider.go
@@ -111,6 +111,7 @@ func Provider() *schema.Provider {
 			"lacework_integration_oci_cfg":                    resourceLaceworkIntegrationOciCfg(),
 			"lacework_integration_proxy_scanner":              resourceLaceworkIntegrationProxyScanner(),
 			"lacework_query":                                  resourceLaceworkQuery(),
+			"lacework_managed_policies":                       resourceLaceworkManagedPolicies(),
 			"lacework_policy":                                 resourceLaceworkPolicy(),
 			"lacework_policy_compliance":                      resourceLaceworkPolicyCompliance(),
 			"lacework_policy_exception":                       resourceLaceworkPolicyException(),

--- a/lacework/resource_lacework_managed_policies.go
+++ b/lacework/resource_lacework_managed_policies.go
@@ -139,11 +139,7 @@ func getBulkUpdatePolicies(d *schema.ResourceData) (api.BulkUpdatePolicies, erro
 		policy := api.BulkUpdatePolicy{
 			PolicyID: policyID,
 			Enabled:  &enabled,
-		}
-
-		if val["severity"] != nil && val["severity"] != "" {
-			severity := val["severity"].(string)
-			policy.Severity = severity
+			Severity: val["severity"].(string),
 		}
 
 		seen[policyID] = true

--- a/lacework/resource_lacework_managed_policies.go
+++ b/lacework/resource_lacework_managed_policies.go
@@ -30,8 +30,7 @@ func resourceLaceworkManagedPolicies() *schema.Resource {
 						"enabled": {
 							Type:        schema.TypeBool,
 							Description: "The state of the policy",
-							Optional:    true,
-							Default:     true,
+							Required:    true,
 						},
 						"severity": {
 							Type:     schema.TypeString,

--- a/lacework/resource_lacework_managed_policies.go
+++ b/lacework/resource_lacework_managed_policies.go
@@ -1,0 +1,135 @@
+package lacework
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/lacework/go-sdk/api"
+)
+
+func resourceLaceworkManagedPolicies() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLaceworkManagedPoliciesCreate,
+		Update: resourceLaceworkManagedPoliciesUpdate,
+		Delete: resourceLaceworkManagedPoliciesDelete,
+		Read:   resourceLaceworkManagedPoliciesRead,
+
+		Importer: &schema.ResourceImporter{
+			State: importLaceworkManagedPolicies,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"policy": {
+				Type: schema.TypeSet,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Description: "The id of the policy",
+							Required:    true,
+						},
+						"enabled": {
+							Type:        schema.TypeBool,
+							Required:    true,
+							Description: "The state of the policy",
+						},
+						"severity": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Description: "The severity for the policy. Valid severities are: " +
+								"Critical, High, Medium, Low, Info",
+							StateFunc: func(val interface{}) string {
+								return strings.TrimSpace(strings.ToLower(val.(string)))
+							},
+							ValidateDiagFunc: ValidSeverity(),
+						},
+					},
+				},
+				Required:    true,
+				Description: "A list of Lacework managed policies",
+			},
+		},
+	}
+}
+
+func resourceLaceworkManagedPoliciesCreate(d *schema.ResourceData, meta interface{}) error {
+	d.SetId(time.Now().UTC().String())
+	return resourceLaceworkManagedPoliciesUpdate(d, meta)
+}
+
+func resourceLaceworkManagedPoliciesUpdate(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+	policies, err := getBulkUpdatePolicies(d, meta)
+
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Updating Policies with data:\n%+v\n", policies)
+	_, updateErr := lacework.V2.Policy.UpdateMany(policies)
+	if updateErr != nil {
+		return updateErr
+	}
+	log.Printf("[INFO] Updated Policies with data:\n%+v\n", policies)
+	return nil
+}
+
+func resourceLaceworkManagedPoliciesRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceLaceworkManagedPoliciesDelete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}
+
+func importLaceworkManagedPolicies(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	log.Print("[INFO] Importing Lacework managed policies")
+	policies, err := getBulkUpdatePolicies(d, meta)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("[INFO] Found Lacework managed policies: \n%+v\n", policies)
+	return []*schema.ResourceData{d}, nil
+}
+
+func getBulkUpdatePolicies(d *schema.ResourceData, meta interface{}) (api.BulkUpdatePolicies, error) {
+	var policies api.BulkUpdatePolicies
+	list := d.Get("policy").(*schema.Set).List()
+	seen := make(map[string]bool, 0)
+
+	for _, v := range list {
+		val := v.(map[string]interface{})
+
+		if val["id"] == nil || val["id"] == "" {
+			continue
+		}
+
+		policyID := val["id"].(string)
+		enabled := val["enabled"].(bool)
+
+		if !strings.HasPrefix(policyID, "lacework-global") {
+			return nil, fmt.Errorf("Unable to update custom policy ID: %s", policyID)
+		}
+		if seen[policyID] == true {
+			return nil, fmt.Errorf("Unable to update duplicate policy ID: %s", policyID)
+		}
+
+		policy := api.BulkUpdatePolicy{
+			PolicyID: policyID,
+			Enabled:  &enabled,
+		}
+
+		if val["severity"] != nil && val["severity"] != "" {
+			severity := val["severity"].(string)
+			policy.Severity = severity
+		}
+
+		seen[policyID] = true
+		policies = append(policies, policy)
+	}
+	return policies, nil
+}

--- a/website/docs/r/managed_policies.html.markdown
+++ b/website/docs/r/managed_policies.html.markdown
@@ -23,12 +23,12 @@ resource "lacework_managed_policies" "example" {
   }
   policy {
     id       = "lacework-global-2"
-    enabled  = true
+    enabled  = false
     severity = "Critical"
   }
   policy {
     id       = "lacework-global-10"
-    enabled  = false
+    severity  = "Low"
   }
 }
 ```
@@ -38,14 +38,6 @@ resource "lacework_managed_policies" "example" {
 For each `policy` block, the following arguments are supported:
 
 * `id` - (Required) The Lacework-defined policy id.
-* `enabled` - (Required) Whether the policy is enabled or disabled.
-* `severity` - (Optional) The list of the severities. Valid severities include:
+* `enabled` - (Optional) Whether the policy is enabled or disabled. Defaults to `true`.
+* `severity` - (Required) The list of the severities. Valid severities include:
   `Critical`, `High`, `Medium`, `Low` and `Info`.
-
-## Import
-
-A lacework_managed_policies resource can be imported using a UTC string as the ID, e.g.
-
-```
-$ terraform import lacework_managed_policies.example "2023-07-19 20:58:07.320676 +0000 UTC"
-```

--- a/website/docs/r/managed_policies.html.markdown
+++ b/website/docs/r/managed_policies.html.markdown
@@ -8,11 +8,11 @@ description: |-
 
 # lacework\_managed\_policies
 
-Use this resource to update the "enabled" and the "severity" property for Lacework defined policies.
+Use this resource to update the "enabled" and the "severity" properties for Lacework-defined policies.
 
 ## Example Usage
 
-Create a lacework_managed_policies resource to manage three Lacework defined policies.
+Create a lacework_managed_policies resource to manage three Lacework-defined policies.
 
 ```hcl
 resource "lacework_managed_policies" "example" {
@@ -37,7 +37,7 @@ resource "lacework_managed_policies" "example" {
 
 The following arguments are supported:
 
-* `id` - (Required) The Lacework defined policy id.
+* `id` - (Required) The Lacework-defined policy id.
 * `enabled` - (Required) Whether the policy is enabled or disabled.
 * `severity` - (Optional) The list of the severities. Valid severities include:
   `Critical`, `High`, `Medium`, `Low` and `Info`.

--- a/website/docs/r/managed_policies.html.markdown
+++ b/website/docs/r/managed_policies.html.markdown
@@ -38,6 +38,6 @@ resource "lacework_managed_policies" "example" {
 For each `policy` block, the following arguments are supported:
 
 * `id` - (Required) The Lacework-defined policy id.
-* `enabled` - (Optional) Whether the policy is enabled or disabled. Defaults to `true`.
+* `enabled` - (Required) Whether the policy is enabled or disabled.
 * `severity` - (Required) The list of the severities. Valid severities include:
   `Critical`, `High`, `Medium`, `Low` and `Info`.

--- a/website/docs/r/managed_policies.html.markdown
+++ b/website/docs/r/managed_policies.html.markdown
@@ -8,23 +8,23 @@ description: |-
 
 # lacework\_managed\_policies
 
-Use this resource to update the "enabled" and the "severity" properties for Lacework-defined policies.
+Use this resource to update the `state` (enabled/disabled) and the `severity` properties for Lacework-defined policies.
 
 ## Example Usage
 
-Create a lacework_managed_policies resource to manage three Lacework-defined policies.
+The following example shows how to manage three Lacework-defined policies.
 
 ```hcl
 resource "lacework_managed_policies" "example" {
   policy {
     id       = "lacework-global-1"
     enabled  = true
-    severity = "high"
+    severity = "High"
   }
   policy {
     id       = "lacework-global-2"
     enabled  = true
-    severity = "critical"
+    severity = "Critical"
   }
   policy {
     id       = "lacework-global-10"
@@ -35,7 +35,7 @@ resource "lacework_managed_policies" "example" {
 
 ## Argument Reference
 
-The following arguments are supported:
+For each `policy` block, the following arguments are supported:
 
 * `id` - (Required) The Lacework-defined policy id.
 * `enabled` - (Required) Whether the policy is enabled or disabled.

--- a/website/docs/r/managed_policies.html.markdown
+++ b/website/docs/r/managed_policies.html.markdown
@@ -28,7 +28,8 @@ resource "lacework_managed_policies" "example" {
   }
   policy {
     id       = "lacework-global-10"
-    severity  = "Low"
+    enabled  = true
+    severity = "Low"
   }
 }
 ```

--- a/website/docs/r/managed_policies.html.markdown
+++ b/website/docs/r/managed_policies.html.markdown
@@ -1,0 +1,43 @@
+---
+subcategory: "Policies"
+layout: "lacework"
+page_title: "Lacework: lacework_managed_policies"
+description: |-
+  Manage Lacework Defined Policies
+---
+
+# lacework\_managed\_policies
+
+Use this resource to update the "enabled" and the "severity" property for Lacework defined policies.
+
+## Example Usage
+
+Create a lacework_managed_policies resource to manage three Lacework defined policies.
+
+```hcl
+resource "lacework_managed_policies" "example" {
+  policy {
+    id       = "lacework-global-1"
+    enabled  = true
+    severity = "high"
+  }
+  policy {
+    id       = "lacework-global-2"
+    enabled  = true
+    severity = "critical"
+  }
+  policy {
+    id       = "lacework-global-10"
+    enabled  = false
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `id` - (Required) The Lacework defined policy id.
+* `enabled` - (Required) Whether the policy is enabled or disabled.
+* `severity` - (Optional) The list of the severities. Valid severities include:
+  `Critical`, `High`, `Medium`, `Low` and `Info`.

--- a/website/docs/r/managed_policies.html.markdown
+++ b/website/docs/r/managed_policies.html.markdown
@@ -41,3 +41,11 @@ For each `policy` block, the following arguments are supported:
 * `enabled` - (Required) Whether the policy is enabled or disabled.
 * `severity` - (Optional) The list of the severities. Valid severities include:
   `Critical`, `High`, `Medium`, `Low` and `Info`.
+
+## Import
+
+A lacework_managed_policies resource can be imported using a UTC string as the ID, e.g.
+
+```
+$ terraform import lacework_managed_policies.example "2023-07-19 20:58:07.320676 +0000 UTC"
+```


### PR DESCRIPTION
## Description:
Create a new resource `lacework_managed_policies` to manage the state (enable/disable) and the severity of Lacework defined policies (policies that start with `lacework-global`)

## Example Usage

```hcl
resource "lacework_managed_policies" "example" {
  policy {
    id       = "lacework-global-1"
    enabled  = true
    severity = "High"
  }
  policy {
    id       = "lacework-global-2"
    enabled  = true
    severity = "Critical"
  }
  policy {
    id       = "lacework-global-10"
    enabled  = false
  }
}
```

## Argument Reference

The following arguments are supported:

* `id` - (Required) The Lacework defined policy id.
* `enabled` - (Required) Whether the policy is enabled or disabled.
* `severity` - (Optional) The list of the severities. Valid severities include:
  `Critical`, `High`, `Medium`, `Low` and `Info`.

## Additional Info:
Run `make integration-test regex=TestManagedPolicies` to test.

Verify that the resource can update the data correctly via the following steps:

![Screenshot 2023-07-19 at 2 00 30 PM](https://github.com/lacework/terraform-provider-lacework/assets/7945666/06e7b69e-2f80-4954-82fa-de925049c1a1)

![Screenshot 2023-07-19 at 2 18 17 PM](https://github.com/lacework/terraform-provider-lacework/assets/7945666/79dc56ec-d68b-4609-9678-f2e6df2b6cf0)

![Screenshot 2023-07-19 at 2 02 20 PM](https://github.com/lacework/terraform-provider-lacework/assets/7945666/c4f5c880-4181-463b-9c81-b21ed7c9f9b4)

