### PR TITLE
feat(55293): Add acct mapping handling gcp agentless

### DIFF
--- a/examples/resource_lacework_integration_aws_org_agentless_scanning/main.tf
+++ b/examples/resource_lacework_integration_aws_org_agentless_scanning/main.tf
@@ -13,7 +13,7 @@ provider "lacework" {
 resource "lacework_integration_aws_org_agentless_scanning" "example" {
   name                      = var.name
   query_text                = var.query_text
-  scan_frequency            = 24
+  scan_frequency            = var.scan_frequency
   scan_containers           = true
   scan_host_vulnerabilities = true
   scan_multi_volume         = false
@@ -48,6 +48,11 @@ resource "lacework_integration_aws_org_agentless_scanning" "example" {
 variable "account_id" {
   type    = string
   default = ""
+}
+
+variable "scan_frequency" {
+  type = number 
+  default = 24
 }
 
 variable "bucket_arn" {

--- a/examples/resource_lacework_integration_gcp_org_agentless_scanning/main.tf
+++ b/examples/resource_lacework_integration_gcp_org_agentless_scanning/main.tf
@@ -1,0 +1,157 @@
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+provider "lacework" {
+    organization = true
+}
+
+variable "name" {
+  type    = string
+  default = "GCP Agentless Scanning org_example"
+}
+
+variable "client_id" {
+  type    = string
+  default = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}
+
+variable "client_email" {
+  type    = string
+  default = "email@some-project-name.iam.gserviceaccount.com"
+}
+
+variable "private_key_id" {
+  type    = string
+  default = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}
+
+variable "private_key" {
+  type    = string
+  default = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+}
+
+variable "token_uri" {
+  type    = string
+  default = "https://oauth2.googleapis.com/token"
+}
+
+variable "integration_type" {
+  type    = string
+  default = "PROJECT"
+}
+
+variable "project_id" {
+  type    = string
+  default = "org-example-project-id"
+}
+
+variable "bucket_name" {
+  type    = string
+  default = "storage bucket id"
+}
+
+variable "scanning_project_id" {
+  type = string
+  default = "scanning-project-id"
+}
+
+variable "query_text" {
+  type    = string
+  default = ""
+}
+
+variable "filter_list" {
+  type    = list(string)
+  default = ["proj1", "proj2"]
+}
+
+variable "scan_frequency" {
+  type = number 
+  default = 24
+}
+
+variable "org_account_mappings" {
+  type = list(object({
+    default_lacework_account = string
+    mapping = list(object({
+      lacework_account = string
+      gcp_projects     = list(string)
+    }))
+  }))
+  default     = []
+  description = "Mapping of GCP projects to Lacework accounts within a Lacework organization"
+}
+
+resource "lacework_integration_gcp_agentless_scanning" "org_example" {
+  name = var.name
+  credentials {
+    client_id      = var.client_id
+    client_email   = var.client_email
+    private_key_id = var.private_key_id
+    private_key    = var.private_key
+    token_uri 	   = var.token_uri
+  }
+  resource_level = "ORGANIZATION"
+  resource_id    = "techally-test"
+  bucket_name = var.bucket_name
+  scanning_project_id = "gcp-lw-scanner"
+  scan_frequency            = var.scan_frequency
+  scan_containers           = true
+  scan_host_vulnerabilities = true
+  scan_multi_volume         = false
+  scan_stopped_instances    = true
+  query_text = var.query_text
+  filter_list = var.filter_list
+
+  dynamic "org_account_mappings" {
+    for_each = var.org_account_mappings
+    content {
+      default_lacework_account = org_account_mappings.value["default_lacework_account"]
+
+      dynamic "mapping" {
+        for_each = org_account_mappings.value["mapping"]
+        content {
+          lacework_account = mapping.value["lacework_account"]
+          gcp_projects     = mapping.value["gcp_projects"]
+        }
+      }
+    }
+  }
+}
+
+output "name" {
+  value = lacework_integration_gcp_agentless_scanning.org_example.name
+}
+
+output "client_id" {
+  value = lacework_integration_gcp_agentless_scanning.org_example.credentials[0].client_id
+}
+
+output "client_email" {
+  value = lacework_integration_gcp_agentless_scanning.org_example.credentials[0].client_email
+}
+
+output "bucket_name" {
+  value = lacework_integration_gcp_agentless_scanning.org_example.bucket_name
+}
+
+output "scanning_project_id" {
+  value = lacework_integration_gcp_agentless_scanning.org_example.scanning_project_id
+}
+
+output "scan_frequency" {
+  value = lacework_integration_gcp_agentless_scanning.org_example.scan_frequency
+}
+
+output "server_token" {
+  value = lacework_integration_gcp_agentless_scanning.org_example.server_token
+}
+
+output "org_account_mappings" {
+  value = lacework_integration_gcp_agentless_scanning.org_example.org_account_mappings
+}

--- a/examples/resource_lacework_integration_gcp_org_agentless_scanning/main.tf
+++ b/examples/resource_lacework_integration_gcp_org_agentless_scanning/main.tf
@@ -7,12 +7,12 @@ terraform {
 }
 
 provider "lacework" {
-    organization = true
+  organization = true
 }
 
-variable "name" {
+variable "integration_name" {
   type    = string
-  default = "GCP Agentless Scanning org_example"
+  default = "GCP Agentless Scanning Example"
 }
 
 variable "client_id" {
@@ -47,7 +47,7 @@ variable "integration_type" {
 
 variable "project_id" {
   type    = string
-  default = "org-example-project-id"
+  default = "example-project-id"
 }
 
 variable "bucket_name" {
@@ -55,7 +55,7 @@ variable "bucket_name" {
   default = "storage bucket id"
 }
 
-variable "scanning_project_id" {
+variable "scanning-project-id" {
   type = string
   default = "scanning-project-id"
 }
@@ -68,11 +68,6 @@ variable "query_text" {
 variable "filter_list" {
   type    = list(string)
   default = ["proj1", "proj2"]
-}
-
-variable "scan_frequency" {
-  type = number 
-  default = 24
 }
 
 variable "org_account_mappings" {
@@ -88,7 +83,7 @@ variable "org_account_mappings" {
 }
 
 resource "lacework_integration_gcp_agentless_scanning" "org_example" {
-  name = var.name
+  name = var.integration_name
   credentials {
     client_id      = var.client_id
     client_email   = var.client_email
@@ -97,14 +92,14 @@ resource "lacework_integration_gcp_agentless_scanning" "org_example" {
     token_uri 	   = var.token_uri
   }
   resource_level = "ORGANIZATION"
-  resource_id    = "techally-test"
-  bucket_name = var.bucket_name
-  scanning_project_id = "gcp-lw-scanner"
-  scan_frequency            = var.scan_frequency
+  resource_id    = "294451184225"
+  scanning_project_id = "techally-test"
+  scan_frequency            = 24
   scan_containers           = true
   scan_host_vulnerabilities = true
   scan_multi_volume         = false
   scan_stopped_instances    = true
+  bucket_name = var.bucket_name
   query_text = var.query_text
   filter_list = var.filter_list
 

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -189,8 +189,18 @@ func GetContainerRegisteryGar(result string) api.GcpGarIntegrationResponse {
 
 func GetGcpAgentlessScanningResponse(result string) api.GcpSidekickIntegrationResponse {
 	id := GetIDFromTerraResults(result)
-
 	res, err := LwClient.V2.CloudAccounts.GetGcpSidekick(id)
+
+	if err != nil {
+		log.Fatalf("Unable to find integration id: %s\n Response: %v", id, res)
+	}
+
+	return res
+}
+
+func GetGcpAgentlessOrgScanningResponse(result string) api.GcpSidekickIntegrationResponse {
+	id := GetIDFromTerraResults(result)
+	res, err := LwOrgClient.V2.CloudAccounts.GetGcpSidekick(id)
 
 	if err != nil {
 		log.Fatalf("Unable to find integration id: %s\n Response: %v", id, res)

--- a/integration/resource_lacework_integration_aws_org_agentless_scanning_test.go
+++ b/integration/resource_lacework_integration_aws_org_agentless_scanning_test.go
@@ -40,7 +40,6 @@ func TestIntegrationAwsOrgAgentlessScanningLog(t *testing.T) {
 	// Create new AWS Agentless Scanning Integration
 	create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
 	createData := GetAwsAgentlessOrgScanningResponse(create)
-	println(create)
 	actualName := terraform.Output(t, terraformOptions, "name")
 	assert.Equal(
 		t,

--- a/integration/resource_lacework_integration_gcp_agentless_scanning_test.go
+++ b/integration/resource_lacework_integration_gcp_agentless_scanning_test.go
@@ -47,3 +47,66 @@ func TestIntegrationGcpAgentlessScanningCreate(t *testing.T) {
 		assert.Equal(t, update_integration_name, updateData.Data.Name)
 	}
 }
+
+func TestIntegrationGcpAgentlessOrgScanningCreate(t *testing.T) {
+	gcreds, err := googleLoadDefaultCredentials()
+	integration_name := "GCP Agentless Scanning Example Integration Test"
+	update_integration_name := fmt.Sprintf("%s Updated", integration_name)
+	if assert.Nil(t, err, "this test requires you to set GOOGLE_CREDENTIALS environment variable") {
+		terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+			TerraformDir: "../examples/resource_lacework_integration_gcp_org_agentless_scanning",
+			Vars: map[string]interface{}{
+				"name":           integration_name,
+				"client_id":      gcreds.ClientID,
+				"client_email":   gcreds.ClientEmail,
+				"private_key_id": gcreds.PrivateKeyID,
+				"bucket_name":    "storage bucket id",
+				"org_account_mappings": []map[string]interface{}{
+					{
+						"default_lacework_account": "customerdemo",
+						"mapping": []map[string]interface{}{
+							{
+								"lacework_account": "abc",
+								"gcp_projects":     []string{"lw-scanner-5"},
+							},
+						},
+					},
+				},
+			},
+			EnvVars: map[string]string{
+				"TF_VAR_private_key": gcreds.PrivateKey,
+				"LW_API_TOKEN":       LwApiToken,
+			},
+		})
+		defer terraform.Destroy(t, terraformOptions)
+
+		// Create new Google Agentless Scanning integration
+		create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+		createData := GetGcpAgentlessScanningResponse(create)
+		assert.Equal(t, integration_name, createData.Data.Name)
+
+		// Update Gcp integration
+		terraformOptions.Vars = map[string]interface{}{
+			"name":           update_integration_name,
+			"client_id":      gcreds.ClientID,
+			"client_email":   gcreds.ClientEmail,
+			"private_key_id": gcreds.PrivateKeyID,
+			"bucket_name":    "storage bucket id",
+			"org_account_mappings": []map[string]interface{}{
+				{
+					"default_lacework_account": "customerdemo",
+					"mapping": []map[string]interface{}{
+						{
+							"lacework_account": "abc",
+							"gcp_projects":     []string{"lw-scanner-5"},
+						},
+					},
+				},
+			},
+		}
+
+		update := terraform.ApplyAndIdempotent(t, terraformOptions)
+		updateData := GetGcpAgentlessScanningResponse(update)
+		assert.Equal(t, update_integration_name, updateData.Data.Name)
+	}
+}

--- a/lacework/account_mapping_helper.go
+++ b/lacework/account_mapping_helper.go
@@ -5,7 +5,7 @@ import (
 )
 
 type accountMappingsFile struct {
-	DefaultLaceworkAccount string                 `json:"defaultLaceworkAccountAws"`
+	DefaultLaceworkAccount string                 `json:"defaultLaceworkAccount"`
 	Mappings               map[string]interface{} `json:"integration_mappings"`
 }
 
@@ -30,13 +30,18 @@ func getResourceOrgAccountMappings(d *schema.ResourceData, mappingsType string) 
 		mappingSet := accountMappings["mapping"].(*schema.Set)
 		for _, m := range mappingSet.List() {
 			mapping := m.(map[string]interface{})
-			accountMapFile.Mappings[mapping["lacework_account"].(string)] = map[string]interface{}{
-				mappingsType: castStringSlice(mapping[mappingsType].(*schema.Set).List()),
+			if mappingsType == "gcp_projects" {
+				accountMapFile.Mappings[mapping["lacework_account"].(string)] = map[string]interface{}{
+					"gcp_projects": castStringSlice(mapping[mappingsType].(*schema.Set).List()),
+				}
+			} else {
+				accountMapFile.Mappings[mapping["lacework_account"].(string)] = map[string]interface{}{
+					"aws_accounts": castStringSlice(mapping[mappingsType].(*schema.Set).List()),
+				}
 			}
 		}
 
 	}
-
 	return accountMapFile
 }
 
@@ -58,21 +63,57 @@ func flattenOrgAccountMappings(mappingFile *accountMappingsFile, mappingsType st
 
 func flattenMappings(mappings map[string]interface{}, mappingsType string) *schema.Set {
 	var (
-		orgAccountMappingsSchema = awsCloudTrailIntegrationSchema["org_account_mappings"].Elem.(*schema.Resource)
-		mappingSchema            = orgAccountMappingsSchema.Schema["mapping"].Elem.(*schema.Resource)
-		accountsSchema           = mappingSchema.Schema[mappingsType].Elem.(*schema.Schema)
-		res                      = schema.NewSet(schema.HashResource(mappingSchema), []interface{}{})
+		awsOrgAccountMappingsSchema = awsCloudTrailIntegrationSchema["org_account_mappings"].Elem.(*schema.Resource)
+		awsMappingSchema            = awsOrgAccountMappingsSchema.Schema["mapping"].Elem.(*schema.Resource)
+		awsAccountsSchema           = awsMappingSchema.Schema[mappingsType].Elem.(*schema.Schema)
+		awsRes                      = schema.NewSet(schema.HashResource(awsMappingSchema), []interface{}{})
 	)
 
 	for laceworkAccount, m := range mappings {
 		mappingValue := m.(map[string]interface{})
-		res.Add(map[string]interface{}{
+		awsRes.Add(map[string]interface{}{
 			"lacework_account": laceworkAccount,
-			mappingsType: schema.NewSet(schema.HashSchema(accountsSchema),
-				mappingValue[mappingsType].([]interface{}),
+			"aws_accounts": schema.NewSet(schema.HashSchema(awsAccountsSchema),
+				mappingValue["aws_accounts"].([]interface{}),
 			),
 		})
 	}
 
-	return res
+	return awsRes
+}
+
+func flattenOrgGcpAccountMappings(mappingFile *accountMappingsFile) []map[string]interface{} {
+	orgAccMappings := make([]map[string]interface{}, 0, 1)
+
+	if mappingFile.Empty() {
+		return orgAccMappings
+	}
+
+	mappings := map[string]interface{}{
+		"default_lacework_account": mappingFile.DefaultLaceworkAccount,
+		"mapping":                  flattenGcpMappings(mappingFile.Mappings),
+	}
+
+	orgAccMappings = append(orgAccMappings, mappings)
+	return orgAccMappings
+}
+
+func flattenGcpMappings(mappings map[string]interface{}) *schema.Set {
+	var (
+		gcpOrgAccountMappingsSchema = gcpAgentlessScanningIntegrationSchema["org_account_mappings"].Elem.(*schema.Resource)
+		gcpMappingSchema            = gcpOrgAccountMappingsSchema.Schema["mapping"].Elem.(*schema.Resource)
+		gcpAccountsSchema           = gcpMappingSchema.Schema["mapping"].Elem.(*schema.Schema)
+		gcpRes                      = schema.NewSet(schema.HashResource(gcpMappingSchema), []interface{}{})
+	)
+
+	for laceworkAccount, m := range mappings {
+		mappingValue := m.(map[string]interface{})
+		gcpRes.Add(map[string]interface{}{
+			"lacework_account": laceworkAccount,
+			"gcp_projects": schema.NewSet(schema.HashSchema(gcpAccountsSchema),
+				mappingValue["gcp_projects"].([]interface{}),
+			),
+		})
+	}
+	return gcpRes
 }

--- a/lacework/account_mapping_helper.go
+++ b/lacework/account_mapping_helper.go
@@ -13,11 +13,6 @@ func (f *accountMappingsFile) Empty() bool {
 	return f.DefaultLaceworkAccount == ""
 }
 
-type typeStruct struct {
-	awsAccounts string
-	gcpProjects string
-}
-
 var awsMappingType string = "aws_accounts"
 var gcpMappingType string = "gcp_projects"
 

--- a/lacework/resource_lacework_integration_aws_ct.go
+++ b/lacework/resource_lacework_integration_aws_ct.go
@@ -135,7 +135,7 @@ func resourceLaceworkIntegrationAwsCloudTrailCreate(d *schema.ResourceData, meta
 		}
 	)
 	// verify if the user provided an account mapping
-	accountMapFile := getResourceOrgAccountMappings(d)
+	accountMapFile := getResourceOrgAccountMappings(d, awsMappingType)
 	if !accountMapFile.Empty() {
 		accountMapFileBytes, err := json.Marshal(accountMapFile)
 		if err != nil {
@@ -234,7 +234,7 @@ func resourceLaceworkIntegrationAwsCloudTrailRead(d *schema.ResourceData, meta i
 
 		}
 
-		err = d.Set("org_account_mappings", flattenOrgAccountMappings(accountMapFile))
+		err = d.Set("org_account_mappings", flattenOrgAccountMappings(accountMapFile, awsMappingType))
 		if err != nil {
 			return fmt.Errorf("Error flattening organization account mapping: %s", err)
 		}
@@ -262,7 +262,7 @@ func resourceLaceworkIntegrationAwsCloudTrailUpdate(d *schema.ResourceData, meta
 	)
 
 	// verify if the user provided an account mapping
-	accountMapFile := getResourceOrgAccountMappings(d)
+	accountMapFile := getResourceOrgAccountMappings(d, awsMappingType)
 	if !accountMapFile.Empty() {
 		accountMapFileBytes, err := json.Marshal(accountMapFile)
 		if err != nil {

--- a/lacework/resource_lacework_integration_aws_org_agentless_scanning.go
+++ b/lacework/resource_lacework_integration_aws_org_agentless_scanning.go
@@ -175,7 +175,7 @@ var awsOrgAgentlessScanningIntegrationSchema = map[string]*schema.Schema{
 							"lacework_account": {
 								Type:        schema.TypeString,
 								Required:    true,
-								Description: "The Lacework account name where the CloudTrail activity from the selected AWS accounts will appear.",
+								Description: "The Lacework account name where the Agentless activity from the selected AWS accounts will appear.",
 							},
 							"aws_accounts": {
 								Type:        schema.TypeSet,

--- a/lacework/resource_lacework_integration_aws_org_agentless_scanning.go
+++ b/lacework/resource_lacework_integration_aws_org_agentless_scanning.go
@@ -214,7 +214,7 @@ func resourceLaceworkIntegrationAwsOrgAgentlessScanningCreate(d *schema.Resource
 	}
 
 	// verify if the user provided an account mapping
-	accountMapFile := getResourceOrgAccountMappings(d)
+	accountMapFile := getResourceOrgAccountMappings(d, awsMappingType)
 	if !accountMapFile.Empty() {
 		accountMapFileBytes, err := json.Marshal(accountMapFile)
 		if err != nil {
@@ -318,7 +318,7 @@ func resourceLaceworkIntegrationAwsOrgAgentlessScanningRead(d *schema.ResourceDa
 
 		}
 
-		err = d.Set("org_account_mappings", flattenOrgAccountMappings(accountMapFile))
+		err = d.Set("org_account_mappings", flattenOrgAccountMappings(accountMapFile, awsMappingType))
 		if err != nil {
 			return fmt.Errorf("Error flattening organization account mapping: %s", err)
 		}
@@ -354,7 +354,7 @@ func resourceLaceworkIntegrationAwsOrgAgentlessScanningUpdate(d *schema.Resource
 	}
 
 	// verify if the user provided an account mapping
-	accountMapFile := getResourceOrgAccountMappings(d)
+	accountMapFile := getResourceOrgAccountMappings(d, awsMappingType)
 	if !accountMapFile.Empty() {
 		accountMapFileBytes, err := json.Marshal(accountMapFile)
 		if err != nil {


### PR DESCRIPTION
***Issue***: https://lacework.atlassian.net/browse/RAIN-55293

***Description:***
This is to drive feature parity with AWS for agentless workload scanning. Currently AWS Organization integrations allow for a customer to provide an account mapping file that maps to lacework sub-accounts. This is Part #2 in enabling that for GCP Agentless via terraform. Part #1 was to add the Account Mapping field to the go-sdk for Gcp Agentless. 

***Changes:***
- Add account mapping field to gcp scanning resource
- Add functionality to update the account mapping accordingly
- Add functionality to the account_mapping_helper to look for either "gcp_projects" for the list of gcp projects or "aws_accounts" for the list of aws_accounts according to the type of integration. 
- Add new integration test for GCP Org and updated example for GCP Org