### PR TITLE
fix(GROW-2361): alert-rules omitempty

### DIFF
--- a/vendor/github.com/lacework/go-sdk/api/alert_rules.go
+++ b/vendor/github.com/lacework/go-sdk/api/alert_rules.go
@@ -154,26 +154,26 @@ const (
 // NewAlertRule returns an instance of the AlertRule struct
 //
 // Basic usage: Initialize a new AlertRule struct, then
-//              use the new instance to do CRUD operations
 //
-//   client, err := api.NewClient("account")
-//   if err != nil {
-//     return err
-//   }
+//	             use the new instance to do CRUD operations
 //
-//   alertRule := api.NewAlertRule(
-//		"Foo",
-//		api.AlertRuleConfig{
-//		Description: "My Alert Rule"
-//		Severities: api.AlertRuleSeverities{api.AlertRuleSeverityHigh,
-//		Channels: []string{"TECHALLY_000000000000AAAAAAAAAAAAAAAAAAAA"},
-//		ResourceGroups: []string{"TECHALLY_111111111111AAAAAAAAAAAAAAAAAAAA"}
-//       },
-//     },
-//   )
+//	  client, err := api.NewClient("account")
+//	  if err != nil {
+//	    return err
+//	  }
 //
-//   client.V2.AlertRules.Create(alertRule)
+//	  alertRule := api.NewAlertRule(
+//			"Foo",
+//			api.AlertRuleConfig{
+//			Description: "My Alert Rule"
+//			Severities: api.AlertRuleSeverities{api.AlertRuleSeverityHigh,
+//			Channels: []string{"TECHALLY_000000000000AAAAAAAAAAAAAAAAAAAA"},
+//			ResourceGroups: []string{"TECHALLY_111111111111AAAAAAAAAAAAAAAAAAAA"}
+//	      },
+//	    },
+//	  )
 //
+//	  client.V2.AlertRules.Create(alertRule)
 func NewAlertRule(name string, rule AlertRuleConfig) AlertRule {
 	return AlertRule{
 		Channels: rule.Channels,
@@ -272,10 +272,10 @@ type AlertRuleFilter struct {
 	Enabled              int      `json:"enabled"`
 	Description          string   `json:"description,omitempty"`
 	Severity             []int    `json:"severity"`
-	ResourceGroups       []string `json:"resourceGroups,omitempty"`
-	EventCategories      []string `json:"eventCategory,omitempty"`
+	ResourceGroups       []string `json:"resourceGroups"`
+	EventCategories      []string `json:"eventCategory"`
 	Sources              []string `json:"sources,omitempty"`
-	AlertCategories      []string `json:"category,omitempty"`
+	AlertCategories      []string `json:"category"`
 	CreatedOrUpdatedTime string   `json:"createdOrUpdatedTime,omitempty"`
 	CreatedOrUpdatedBy   string   `json:"createdOrUpdatedBy,omitempty"`
 }


### PR DESCRIPTION
***Issue***:

https://lacework.atlassian.net/browse/GROW-2361

***Description:***

Empty arrays are being ignored by JSON serialisation config.

***Additional Info:***

Tested alert-rule creation and update with the following fields with values, empty array, and missing:
- resource_groups
- alert_categories
- event_categories