### PR TITLE
fix: do not update private key id on read

### DIFF
--- a/lacework/resource_lacework_integration_gcp_agentless_scanning.go
+++ b/lacework/resource_lacework_integration_gcp_agentless_scanning.go
@@ -319,7 +319,6 @@ func resourceLaceworkIntegrationGcpAgentlessScanningRead(d *schema.ResourceData,
 		creds := make(map[string]string)
 		creds["client_id"] = integration.Data.Credentials.ClientID
 		creds["client_email"] = integration.Data.Credentials.ClientEmail
-		creds["private_key_id"] = integration.Data.Credentials.PrivateKeyID
 		creds["token_uri"] = integration.Data.Credentials.TokenUri
 		d.Set("credentials", []map[string]string{creds})
 		d.Set("resource_level", integration.Data.IDType)


### PR DESCRIPTION
**Summary**
Terraform update for https://github.com/lacework/terraform-gcp-agentless-scanning fails as the private key id is empty.
On investigating with @afiune , we found that the patch workflow sends empty key instead of omitting it from the request.

**How did you test this change?**
Update the terraform provider with the go-sdk changes (https://github.com/lacework/go-sdk/pull/1352) and pointed terraform module to use the provider. Terraform update went through successfully,

**Issue**
https://lacework.atlassian.net/browse/LINK-1923