### PR TITLE
fix: resource_id and empty id in agentless GCP

### DIFF
--- a/lacework/resource_lacework_integration_gcp_agentless_scanning.go
+++ b/lacework/resource_lacework_integration_gcp_agentless_scanning.go
@@ -282,7 +282,7 @@ func resourceLaceworkIntegrationGcpAgentlessScanningCreate(d *schema.ResourceDat
 		d.Set("name", integration.Name)
 		d.Set("intg_guid", integration.IntgGuid)
 		d.Set("enabled", integration.Enabled == 1)
-		d.Set("resource_id", integration.IntgGuid)
+		d.Set("resource_id", integration.ID)
 		d.Set("created_or_updated_time", integration.CreatedOrUpdatedTime)
 		d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
 		d.Set("type_name", integration.Type)
@@ -344,8 +344,6 @@ func resourceLaceworkIntegrationGcpAgentlessScanningRead(d *schema.ResourceData,
 			api.GcpSidekickCloudAccount.String(), integration.IntgGuid)
 		return nil
 	}
-
-	d.SetId("")
 	return nil
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-provider-lacework/blob/main/CONTRIBUTING.md
--->

***Issue***: 
Those were noticed while I was referring to GCP lacework provider for Azure.

1. `resource_id` should be the id, not integration id. resource_id should be [either a project id or an org id](https://github.com/lacework/terraform-provider-lacework/blame/main/lacework/resource_lacework_integration_gcp_agentless_scanning.go#L124-L127), whereas the intgGuid is [the common integration id](https://github.com/lacework/terraform-provider-lacework/blame/main/lacework/resource_lacework_integration_gcp_agentless_scanning.go#L32-L35)
2. the setID("") was not needed

Test w/ the integration test.
