### PR TITLE
ci: add initial github workflows to replace codefresh

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,104 @@
+name: Nightly Build
+
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: '0 10 * * *' # Run every day at 10AM UTC
+
+jobs:
+  run-unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
+
+      - name: Run Unit Tests
+        id: unit
+        run: |
+          make prepare
+          make test
+          make fmtcheck
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
+
+      - name: Build 
+        id: build
+        run: |
+          make prepare
+          build-cross-platform
+
+  run-integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      # To wait for the existing nightly-build run to complete to avoid running same integration tests at the same time
+      - name: Turnstyle
+        uses: softprops/turnstyle@v1
+        with:
+          same-branch-only: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
+
+      - name: Run Integration Tests
+        id: integration
+        run: |
+          make prepare
+          make clean-test
+          make integration-test
+
+  slack-notify:
+    name: Slack Notify if Failed Tests
+    needs: [run-unit-tests, build, run-integration-tests]
+    runs-on: ubuntu-latest
+    if: needs.run-unit-tests.result == 'failure' || needs.build.result == 'failure' || needs.run-integration-tests.result == 'failure'
+    steps:
+      - name: Notify Slack on Failure
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#E92020",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure <${{ github.server_url }}/${{ github.repository }}>*\n\n*Workflow Run*\n <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.TF_SLACK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,3 +1,5 @@
+name: Prepare Release
+
 on: workflow_dispatch
 
 jobs:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,53 @@
+on: workflow_dispatch
+
+jobs:
+  prepare-release:  
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.TOKEN }}
+
+
+      - name: Prepare release
+        shell: bash
+        run: |
+          echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
+          scripts/release.sh prepare
+        env:
+          GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+
+  slack-notify:
+    name: Slack Notify if Failed Tests
+    needs: prepare-release
+    runs-on: ubuntu-latest
+    if: needs.prepare-release.result == 'failure'
+    steps:
+      - name: Notify Slack on Failure
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#E92020",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure <${{ github.server_url }}/${{ github.repository }}>*\n\n*Workflow Run*\n <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.TF_SLACK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+on: workflow_call
+
+jobs:
+  tf-release:  
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.TOKEN }}
+
+      - name: Prepare release
+        shell: bash
+        run: |
+          echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
+          scripts/release.sh publish
+        env:
+          GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+
+  slack-notify:
+    name: Slack Notify if Failed Tests
+    needs: tf-release
+    runs-on: ubuntu-latest
+    if: needs.tf-release.result == 'failure'
+    steps:
+      - name: Notify Slack on Failure
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#E92020",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure <${{ github.server_url }}/${{ github.repository }}>*\n\n*Workflow Run*\n <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.TF_SLACK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+name: Release 
+
 on: workflow_call
 
 jobs:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,155 @@
+name: Nightly Build
+
+on:
+  workflow_dispatch:
+  # pull_request:
+  # push:
+
+jobs:
+  run-unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
+
+      - name: Run Unit Tests
+        id: unit
+        run: |
+          make prepare
+          make test
+          make fmtcheck
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
+
+      - name: Build 
+        id: build
+        run: |
+          make prepare
+          build-cross-platform
+
+  run-integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      # To wait for the existing nightly-build run to complete to avoid running same integration tests at the same time
+      - name: Turnstyle
+        uses: softprops/turnstyle@v1
+        with:
+          same-branch-only: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
+          
+      - name: Run Integration Tests
+        id: integration
+        run: |
+          make prepare
+          make clean-test
+          make integration-test
+
+  slack-notify:
+    name: Slack Notify if Failed Tests
+    needs: [run-unit-tests, build, run-integration-tests]
+    runs-on: ubuntu-latest
+    if: needs.run-unit-tests.result == 'failure' || needs.build.result == 'failure' || needs.run-integration-tests.result == 'failure'
+    steps:
+      - name: Notify Slack on Failure
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#E92020",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure <${{ github.server_url }}/${{ github.repository }}>*\n\n*Workflow Run*\n <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.TF_SLACK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+  trigger-release:
+    if: github.ref == 'refs/heads/main'
+    needs: [run-unit-tests, build,  run-integration-tests]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.TOKEN }}
+    
+    - name: Trigger release
+      shell: bash
+      run: |
+        make prepare
+        echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
+        make release
+      env:
+        GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
+        GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+        GITHUB_TOKEN: ${{ secrets.TOKEN }}
+
+  slack-notify-trigger-release:
+    name: Slack Notify if Failed Tests
+    needs: trigger-release
+    runs-on: ubuntu-latest
+    if: needs.trigger-release.result == 'failure' 
+    steps:
+      - name: Notify Slack on Failure
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#E92020",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure <${{ github.server_url }}/${{ github.repository }}>*\n\n*Workflow Run*\n <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.TF_SLACK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,4 +1,4 @@
-name: Nightly Build
+name: Test Build
 
 on:
   workflow_dispatch:

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -1,3 +1,5 @@
+name: Verify Release
+
 on: workflow_call
 
 jobs:

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -1,0 +1,19 @@
+on: workflow_call
+
+jobs:
+  verify-release:  
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: release
+          fetch-depth: 0
+        
+      - name: Verify release
+        shell: bash
+        run: |
+          git remote set-head origin main
+          scripts/release.sh verify


### PR DESCRIPTION

***Issue***: 

https://lacework.atlassian.net/browse/GROW-2760

***Description:***

These are initial versions of the workflows to replace codefresh. These are likely not final but I need some version of these in main to be able to execute them in my branch. These are currently set to manual execution only. 
