### PR TITLE
chore: add the optional `queryLanguage` enum value where used

### DIFF
--- a/examples/resource_lacework_query/main.tf
+++ b/examples/resource_lacework_query/main.tf
@@ -16,6 +16,11 @@ variable "query_id" {
   default = "Lql_Terraform_Query"
 }
 
+variable "query_id" {
+  type    = string
+  default = ""
+}
+
 variable "query" {
   type    = string
   default = <<EOT
@@ -38,6 +43,10 @@ EOT
 
 output "query_id" {
   value = lacework_query.example.id
+}
+
+output "query_language" {
+  value = lacework_query.example.query_language
 }
 
 output "query" {

--- a/examples/resource_lacework_query/main.tf
+++ b/examples/resource_lacework_query/main.tf
@@ -16,7 +16,7 @@ variable "query_id" {
   default = "Lql_Terraform_Query"
 }
 
-variable "query_id" {
+variable "query_language" {
   type    = string
   default = ""
 }

--- a/lacework/resource_lacework_policy.go
+++ b/lacework/resource_lacework_policy.go
@@ -196,7 +196,9 @@ func resourceLaceworkPolicyCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.SetId(response.Data.PolicyID)
-	d.Set("query_language", response.Data.QueryLanguage)
+	if response.Data.QueryLanguage != nil {
+		d.Set("query_language", response.Data.QueryLanguage)
+	}
 	d.Set("owner", response.Data.Owner)
 	d.Set("updated_time", response.Data.LastUpdateTime)
 	d.Set("updated_by", response.Data.LastUpdateUser)
@@ -220,7 +222,9 @@ func resourceLaceworkPolicyRead(d *schema.ResourceData, meta interface{}) error 
 	d.SetId(response.Data.PolicyID)
 	d.Set("title", response.Data.Title)
 	d.Set("query_id", response.Data.QueryID)
-	d.Set("query_language", response.Data.QueryLanguage)
+	if response.Data.QueryLanguage != nil {
+		d.Set("query_language", *response.Data.QueryLanguage)
+	}
 	d.Set("enabled", response.Data.Enabled)
 	d.Set("description", response.Data.Description)
 	d.Set("evaluation", response.Data.EvalFrequency)

--- a/lacework/resource_lacework_policy.go
+++ b/lacework/resource_lacework_policy.go
@@ -34,6 +34,13 @@ func resourceLaceworkPolicy() *schema.Resource {
 				Required:    true,
 				Description: "The id of the query",
 			},
+			"query_language": {
+				Type:        schema.TypeString,
+				Required:    false,
+				Optional:    true,
+				Computed:    true,
+				Description: "The language of the query/module",
+			},
 			"description": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -189,6 +196,7 @@ func resourceLaceworkPolicyCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.SetId(response.Data.PolicyID)
+	d.Set("query_language", response.Data.QueryLanguage)
 	d.Set("owner", response.Data.Owner)
 	d.Set("updated_time", response.Data.LastUpdateTime)
 	d.Set("updated_by", response.Data.LastUpdateUser)
@@ -212,6 +220,7 @@ func resourceLaceworkPolicyRead(d *schema.ResourceData, meta interface{}) error 
 	d.SetId(response.Data.PolicyID)
 	d.Set("title", response.Data.Title)
 	d.Set("query_id", response.Data.QueryID)
+	d.Set("query_language", response.Data.QueryLanguage)
 	d.Set("enabled", response.Data.Enabled)
 	d.Set("description", response.Data.Description)
 	d.Set("evaluation", response.Data.EvalFrequency)

--- a/lacework/resource_lacework_policy_compliance.go
+++ b/lacework/resource_lacework_policy_compliance.go
@@ -135,7 +135,9 @@ func resourceLaceworkPolicyComplianceCreate(d *schema.ResourceData, meta interfa
 	}
 
 	d.SetId(response.Data.PolicyID)
-	d.Set("query_language", response.Data.QueryLanguage)
+	if response.Data.QueryLanguage != nil {
+		d.Set("query_language", response.Data.QueryLanguage)
+	}
 	d.Set("owner", response.Data.Owner)
 	d.Set("updated_time", response.Data.LastUpdateTime)
 	d.Set("updated_by", response.Data.LastUpdateUser)
@@ -159,7 +161,9 @@ func resourceLaceworkPolicyComplianceRead(d *schema.ResourceData, meta interface
 	d.SetId(response.Data.PolicyID)
 	d.Set("title", response.Data.Title)
 	d.Set("query_id", response.Data.QueryID)
-	d.Set("query_language", response.Data.QueryLanguage)
+	if response.Data.QueryLanguage != nil {
+		d.Set("query_language", response.Data.QueryLanguage)
+	}
 	d.Set("enabled", response.Data.Enabled)
 	d.Set("description", response.Data.Description)
 	d.Set("severity", response.Data.Severity)

--- a/lacework/resource_lacework_policy_compliance.go
+++ b/lacework/resource_lacework_policy_compliance.go
@@ -33,6 +33,13 @@ func resourceLaceworkPolicyCompliance() *schema.Resource {
 				Required:    true,
 				Description: "The id of the query",
 			},
+			"query_language": {
+				Type:        schema.TypeString,
+				Required:    false,
+				Optional:    true,
+				Computed:    true,
+				Description: "The language of the query/module",
+			},
 			"description": {
 				Type:        schema.TypeString,
 				Required:    true,

--- a/lacework/resource_lacework_policy_compliance.go
+++ b/lacework/resource_lacework_policy_compliance.go
@@ -135,6 +135,7 @@ func resourceLaceworkPolicyComplianceCreate(d *schema.ResourceData, meta interfa
 	}
 
 	d.SetId(response.Data.PolicyID)
+	d.Set("query_language", response.Data.QueryLanguage)
 	d.Set("owner", response.Data.Owner)
 	d.Set("updated_time", response.Data.LastUpdateTime)
 	d.Set("updated_by", response.Data.LastUpdateUser)
@@ -158,6 +159,7 @@ func resourceLaceworkPolicyComplianceRead(d *schema.ResourceData, meta interface
 	d.SetId(response.Data.PolicyID)
 	d.Set("title", response.Data.Title)
 	d.Set("query_id", response.Data.QueryID)
+	d.Set("query_language", response.Data.QueryLanguage)
 	d.Set("enabled", response.Data.Enabled)
 	d.Set("description", response.Data.Description)
 	d.Set("severity", response.Data.Severity)

--- a/lacework/resource_lacework_query.go
+++ b/lacework/resource_lacework_query.go
@@ -85,14 +85,17 @@ func resourceLaceworkQueryCreate(d *schema.ResourceData, meta interface{}) error
 		lacework = meta.(*api.Client)
 	)
 
-	// TODOs get the query
 	var queryLanguage string
 	if queryLanguageRaw := d.Get("query_language"); queryLanguageRaw != nil {
 		queryLanguage = queryLanguageRaw.(string)
 	}
+	var queryLanguagePtr *string
+	if queryLanguage != "" {
+		queryLanguagePtr = &queryLanguage
+	}
 	query := api.NewQuery{
 		QueryID:       d.Get("query_id").(string),
-		QueryLanguage: &queryLanguage,
+		QueryLanguage: queryLanguagePtr,
 		QueryText:     d.Get("query").(string),
 	}
 
@@ -124,7 +127,9 @@ func resourceLaceworkQueryRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("query", response.Data.QueryText)
-	d.Set("query_language", response.Data.QueryLanguage)
+	if response.Data.QueryLanguage != nil {
+		d.Set("query_language", *response.Data.QueryLanguage)
+	}
 	d.Set("owner", response.Data.Owner)
 	d.Set("updated_time", response.Data.LastUpdateTime)
 	d.Set("updated_by", response.Data.LastUpdateUser)

--- a/lacework/resource_lacework_query.go
+++ b/lacework/resource_lacework_query.go
@@ -51,7 +51,7 @@ func resourceLaceworkQuery() *schema.Resource {
 				Description: "The language of the query or module. Valid values are: LQL, Rego. " +
 					"If omitted, the language is defaulted to LQL.",
 				StateFunc: func(val interface{}) string {
-					return strings.TrimSpace(strings.ToLower(val.(string)))
+					return strings.TrimSpace(val.(string))
 				},
 				ValidateDiagFunc: ValidateQueryLanguage(),
 			},

--- a/lacework/resource_lacework_query.go
+++ b/lacework/resource_lacework_query.go
@@ -3,12 +3,29 @@ package lacework
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/lacework/go-sdk/api"
 	"github.com/pkg/errors"
 )
+
+func ValidateQueryLanguage() schema.SchemaValidateDiagFunc {
+	return validation.ToDiagFunc(func(value interface{}, key string) ([]string, []error) {
+		switch value.(string) {
+		case "LQL", "Rego":
+			return nil, nil
+		default:
+			return nil, []error{
+				fmt.Errorf(
+					"%s: can only be 'LQL', 'Rego'", key,
+				),
+			}
+		}
+	})
+}
 
 func resourceLaceworkQuery() *schema.Resource {
 	return &schema.Resource{
@@ -26,6 +43,17 @@ func resourceLaceworkQuery() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The id of the query",
+			},
+			"query_language": {
+				Type:     schema.TypeString,
+				Required: false,
+				Optional: true,
+				Description: "The language of the query or module. Valid values are: LQL, Rego. " +
+					"If omitted, the language is defaulted to LQL.",
+				StateFunc: func(val interface{}) string {
+					return strings.TrimSpace(strings.ToLower(val.(string)))
+				},
+				ValidateDiagFunc: ValidateQueryLanguage(),
 			},
 			"query": {
 				Type:        schema.TypeString,
@@ -57,9 +85,12 @@ func resourceLaceworkQueryCreate(d *schema.ResourceData, meta interface{}) error
 		lacework = meta.(*api.Client)
 	)
 
+	// TODOs get the query
+
 	query := api.NewQuery{
-		QueryID:   d.Get("query_id").(string),
-		QueryText: d.Get("query").(string),
+		QueryID:       d.Get("query_id").(string),
+		QueryLanguage: d.Get("query_language").(*string),
+		QueryText:     d.Get("query").(string),
 	}
 
 	log.Printf("[INFO] Creating Query with data:\n%+v\n", query)
@@ -90,6 +121,7 @@ func resourceLaceworkQueryRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("query", response.Data.QueryText)
+	d.Set("query_language", response.Data.QueryLanguage)
 	d.Set("owner", response.Data.Owner)
 	d.Set("updated_time", response.Data.LastUpdateTime)
 	d.Set("updated_by", response.Data.LastUpdateUser)
@@ -107,7 +139,9 @@ func resourceLaceworkQueryUpdate(d *schema.ResourceData, meta interface{}) error
 	if d.HasChange("query_id") {
 		return errors.New("unable to change ID of an existing query")
 	}
-
+	if d.HasChange("query_language") {
+		return errors.New("unable to change query_language of an existing query")
+	}
 	query := api.UpdateQuery{
 		QueryText: d.Get("query").(string),
 	}

--- a/lacework/resource_lacework_query.go
+++ b/lacework/resource_lacework_query.go
@@ -86,10 +86,13 @@ func resourceLaceworkQueryCreate(d *schema.ResourceData, meta interface{}) error
 	)
 
 	// TODOs get the query
-
+	var queryLanguage string
+	if queryLanguageRaw := d.Get("query_language"); queryLanguageRaw != nil {
+		queryLanguage = queryLanguageRaw.(string)
+	}
 	query := api.NewQuery{
 		QueryID:       d.Get("query_id").(string),
-		QueryLanguage: d.Get("query_language").(*string),
+		QueryLanguage: &queryLanguage,
 		QueryText:     d.Get("query").(string),
 	}
 


### PR DESCRIPTION

***Issue***: https://lacework.atlassian.net/browse/RAIN-93039

***Description:***
This change adds the `queryLanguage` enumeration to the lacework_query and lacework_policy_compliance resource types.

For a query, it is an optional part of the create submission. It is also an optional part of query payload response from the result of creating, updating, or retrieving the definition of a query.

For a policy, it is an optional part of the response from creating, updating or retrieving the definition of a policy.


***Additional Info:***
Include any other relevant information such as how to use the new functionality, screenshots, etc.