### PR TITLE
ci: fix swapped release commands in release workflows

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -15,13 +15,12 @@ jobs:
           fetch-depth: 0
           ref: main
 
-
-
       - name: Prepare release
         shell: bash
         run: |
+          make prepare
           echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
-          scripts/release.sh prepare
+          make release
         env:
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,10 @@ jobs:
           token: ${{ secrets.TOKEN }}
           ref: ${{ github.ref }}
 
-      - name: Prepare release
+      - name: Release
         shell: bash
         run: |
+          make prepare
           echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
           scripts/release.sh publish
         env:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -133,13 +133,17 @@ jobs:
       uses: actions/checkout@v4
       with:
         token: ${{ secrets.TOKEN }}
+
+    - name: Install gox
+      shell: bash
+      run: |
+        apt install gox -y
     
     - name: Trigger release
       shell: bash
       run: |
-        make prepare
         echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
-        make release
+        scripts/release.sh trigger
       env:
         GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
         GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}


### PR DESCRIPTION
***Issue***: 

https://lacework.atlassian.net/browse/GROW-2760

***Description:***

Some of the github workflows have the incorrect commands for that workflow. 
