### PR TITLE
ci: add sudo to apt-get install command

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -133,11 +133,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         token: ${{ secrets.TOKEN }}
-
-    - name: Install gox
-      shell: bash
-      run: |
-        sudo apt-get -y install gox
     
     - name: Trigger release
       shell: bash

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -137,7 +137,7 @@ jobs:
     - name: Install gox
       shell: bash
       run: |
-        apt install gox -y
+        sudo apt-get -y install gox
     
     - name: Trigger release
       shell: bash


### PR DESCRIPTION

***Issue***: 

https://lacework.atlassian.net/browse/GROW-2760

***Description:***
Sudo command missing from apt-get install causing failure

