### PR TITLE
docs(policy): Reflect API constraints in policy suffix docs

### DIFF
--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -81,7 +81,10 @@ The following arguments are supported:
 * `limit` - (Optional) Set the maximum number of records returned by the policy.
    Maximum value is `5000`. Defaults to `1000`
 * `enabled` - (Optional) Whether the policy is enabled or disabled. Defaults to `true`.
-* `policy_id_suffix` - (Optional) The string appended to the end of the policy id.
+* `policy_id_suffix` - (Optional) The string appended to the end of the policy id. . If specified,
+  the policy id will be `<tenant name>-<policy_id_suffix>`. Supported format is `<policy identifier>`
+  all lowercase up to 16 characters, followed by optional `-<numeric identifier>` up to 8 digits.
+  For example: `abcd-1234` will make policy id `tenantname-abcd-1234`.
 * `tags` - (Optional) A list of policy tags.
 * `alerting` - (Optional) Alerting. See [Alerting](#alerting) below for details.
 

--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -81,7 +81,7 @@ The following arguments are supported:
 * `limit` - (Optional) Set the maximum number of records returned by the policy.
    Maximum value is `5000`. Defaults to `1000`
 * `enabled` - (Optional) Whether the policy is enabled or disabled. Defaults to `true`.
-* `policy_id_suffix` - (Optional) The string appended to the end of the policy id. . If specified,
+* `policy_id_suffix` - (Optional) The string appended to the end of the policy id. If specified,
   the policy id will be `<tenant name>-<policy_id_suffix>`. Supported format is `<policy identifier>`
   all lowercase up to 16 characters, followed by optional `-<numeric identifier>` up to 8 digits.
   For example: `abcd-1234` will make policy id `tenantname-abcd-1234`.


### PR DESCRIPTION
# Description:

When creating a new policy, the suffix, if specified, is sent as `PolicyId` field to the API. This applies constraints to the ID that are not reflected in the docs and can't be easily deduced from the name of the attribute. This leads to debugging 400 API errors.

# Additional Info:

After having read the documentation I had 3 attempts to run `terraform apply` before I figured out what was expected. The error messages from the API were not helpful as they refer to the field as `PolicyId` which it was not.

## Attempt 1

`policy_id_suffix = "-tenant"` causes:

```text
│ Error: 
│   [POST] https://tenant.lacework.net/api/v2/Policies
│   [400] Error: unable to create policy using policyId '-tenant'. Supported format for policyId is '<policy identifier>' all lowercase up to 16 characters, followed by optional '-<numeric identifier>' up to 8 digits. For example: 'abcd-1234'
```

## Attempt 2

`policy_id_suffix = "tenant-123"` causes

```text
│ Error: 
│   [POST] https://tenant.lacework.net/api/v2/Policies
│   [400] Error: unable to create policy using policyId '123'. Supported format for policyId is '<policy identifier>' all lowercase up to 16 characters, followed by optional '-<numeric identifier>' up to 8 digits. For example: 'abcd-1234'
```

## Attempt 3

`policy_id_suffix = "custom-123"` works