### PR TITLE
fix(LINK-3033): set query_id when importing lacework_resource_query

### DIFF
--- a/lacework/resource_lacework_query.go
+++ b/lacework/resource_lacework_query.go
@@ -90,6 +90,7 @@ func resourceLaceworkQueryRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("query", response.Data.QueryText)
+	d.Set("query_id", response.Data.QueryID)
 	d.Set("owner", response.Data.Owner)
 	d.Set("updated_time", response.Data.LastUpdateTime)
 	d.Set("updated_by", response.Data.LastUpdateUser)


### PR DESCRIPTION
***Issue***: https://lacework.atlassian.net/browse/LINK-3033

***Description:***
The issue is when importing lacework_resource_query, the `query_id` is not set which causes a state drift. This PR fixes it.