### PR TITLE
chore: remove run-integration-tests to unblock release process

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,6 +1,6 @@
 name: Test Build
 
-on: 
+on:
   workflow_dispatch:
   pull_request:
     branches:
@@ -43,7 +43,7 @@ jobs:
         with:
           go-version: 1.21.x
 
-      - name: Build 
+      - name: Build
         id: build
         run: |
           make prepare
@@ -69,7 +69,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
-          
+
       - name: Run Integration Tests
         id: integration
         run: |
@@ -126,14 +126,14 @@ jobs:
 
   trigger-release:
     if: github.ref == 'refs/heads/main'
-    needs: [run-unit-tests, build,  run-integration-tests]
+    needs: [run-unit-tests, build] #TODO: Add back run-integration-tests when RGv1 is removed
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
         token: ${{ secrets.TOKEN }}
-    
+
     - name: Trigger release
       shell: bash
       run: |
@@ -148,7 +148,7 @@ jobs:
     name: Slack Notify if Failed Tests
     needs: trigger-release
     runs-on: ubuntu-latest
-    if: always() 
+    if: always()
     steps:
       - name: Notify Slack on Failure
         if: ${{ contains(needs.*.result, 'failure') }}


### PR DESCRIPTION
***Description:***
Resource group v1 is disabled so integration tests are failing. This PR removes integration tests from the release job dependencies for now.