### PR TITLE
chore(CAD-828): create the v1 to v2 resource group conversion doc

### DIFF
--- a/docs/resources/convert_v1_to_v2_resource_groups.md
+++ b/docs/resources/convert_v1_to_v2_resource_groups.md
@@ -1,0 +1,261 @@
+---
+subcategory: "Resource Groups"
+layout: "lacework"
+page_title: "Lacework: convert_to_newer_resource_group"
+description: |-
+  Converts V1 to V2 resource groups
+---
+
+# convert_to_newer_resource_group
+
+The new version of resource groups changes the Terraform syntax used to create the resource groups. 
+The older version of resource groups defined specific filter fields for each of the resource group 
+types. The newer version defines a group argument for an expression tree representing the 
+relationships between resources.
+
+Refer to Filterable Fields section [here](https://docs.fortinet.com/document/lacework-forticnapp/latest/api-reference/690087/using-the-resource-groups-api
+) for supported resource group filters
+
+# Lacework Account Resource Groups
+
+There is no new version for lacework account resource groups so no conversion is applicable for 
+these organizational level resource groups.
+
+# AWS Resource Groups
+
+## Older Resource Group
+
+The older AWS resource group supported the accounts list field to consist of the accounts to be
+included in the resource group. If any of the accounts in the resource group matched an entry in the
+list, the resource group would be applied.
+
+### Example Representation
+
+```hcl
+resource "lacework_resource_group_aws" "example" {
+      name        = "My AWS Resource Group"
+      description = "This groups a subset of AWS Accounts"
+      accounts    = ["123456789", "234567891"]
+}
+```
+
+## Newer Resource Group
+
+The new resource group supports an expression tree structure in which the field key in the filter
+object would be called Account and the value key would be a list containing the values.
+
+### Example Representation
+
+```hcl
+resource "lacework_resource_group" "example" {
+  name        = "My AWS Resource Group"
+  type        = "AWS"
+  description = "This groups a subset of AWS resources"
+  group {
+    operator = "OR"
+    filter {
+      filter_name = "filter1"
+      field     = "Account"
+      operation = "EQUALS"
+      value     = ["123456789", "234567891"]
+    }
+  }
+}
+```
+
+# Azure Resource Groups
+
+## Older Resource Group
+
+The older Azure resource group supported the tenant field and a list of subscriptions within that 
+tenant to be included in the resource group.
+
+### Example Representation
+
+```hcl
+resource "lacework_resource_group_azure" "example" {
+  name          = "My Azure Resource Group"
+  description   = "This groups a subset of Azure Subscriptions"
+  tenant        = "a11aa1ab-111a-11ab-a000-11aa1111a11a"
+  subscriptions = ["1a1a0b2-abc0-1ab1-1abc-1a000ab0a0a0", "2b000c3-ab10-1a01-1abc-1a000ab0a0a0"]
+}
+```
+
+## Newer Resource Group
+
+The new resource group representation for the resource group above would support an expression 
+tree structure in which the field key in the filter objects would be called either Tenant ID or Subscription ID and the value key would be a list 
+containing the values.
+
+### Example Representation
+
+```hcl
+resource "lacework_resource_group_azure" "example" {
+  name        = "My Azure Resource Group"
+  type        = "AZURE"
+  description = "This groups a subset of Azure Subscriptions"
+  group {
+    operator = "AND"
+    filter {
+      filter_name = "filter1"
+      field     = "Tenant"
+      operation = "EQUALS"
+      value     = ["a11aa1ab-111a-11ab-a000-11aa1111a11a"]
+    }
+    group {
+        operator = "OR"
+        filter {
+          filter_name = "filter2"
+          field     = "Subscription ID"
+          operation = "EQUALS"
+          value     = ["1a1a0b2-abc0-1ab1-1abc-1a000ab0a0a0", "2b000c3-ab10-1a01-1abc-1a000ab0a0a0"]
+        }
+    }
+  }
+}
+```
+
+# GCP Resource Groups
+
+## Older Resource Group
+
+The older GCP resource group supported the organization field and a list of projects within that 
+organization to be included in the resource group.
+
+### Example Representation
+
+```hcl
+resource "lacework_resource_group_gcp" "example" {
+  name         = "My GCP Resource Group"
+  description  = "This groups a subset of Gcp Projects"
+  projects     = ["project-1", "project-2", "project-3"]
+  organization = "MyGcpOrgID"
+}
+```
+
+## Newer Resource Group
+
+The new resource group representation for the resource group above would support an expression
+tree structure in which the field key in the filter objects would be called either Organization 
+ID or Project ID and the value key would be a list containing the values.
+
+### Example Representation
+
+```hcl
+resource "lacework_resource_group_gcp" "example" {
+  name        = "My GCP Resource Group"
+  type        = "GCP"
+  description = "This groups a subset of Gcp Projects"
+  group {
+    operator = "AND"
+    filter {
+      filter_name = "filter1"
+      field     = "Organization ID"
+      operation = "EQUALS"
+      value     = ["MyGcpOrgID"]
+    }
+    filter {
+      filter_name = "filter2"
+      field     = "Project ID"
+      operation = "EQUALS"
+      value     = ["project-1", "project-2", "project-3"]
+    }
+  }
+}
+```
+
+# Container Resource Groups
+
+## Older Resource Group
+
+The older Container resource group supported the fields container tags and labels.
+
+### Example Representation
+
+```hcl
+resource "lacework_resource_group_container" "example" {
+  name           = "My Container Resource Group"
+  description    = "This groups a subset of Container Tags"
+  container_tags = ["my-container"]
+  container_label {
+    key   = "name"
+    value = "my-container"
+  }
+}
+```
+
+## Newer Resource Group
+
+The new resource group representation for the resource group above would support an expression
+tree structure in which the field key in the filter objects would be called either Image Tag or 
+Container Label and the value key would be a list containing the values.
+
+### Example Representation
+
+```hcl
+resource "lacework_resource_group_container" "example" {
+  name        = "My Container Resource Group"
+  type        = "CONTAINER"
+  description = "This groups a subset of Container Tags"
+  group {
+    operator = "AND"
+    filter {
+      filter_name = "filter1"
+      field     = "Image Tag"
+      operation = "EQUALS"
+      value     = ["my-container"]
+   }
+   filter {
+      filter_name = "filter2"
+      field     = "Container Label"
+      operation = "EQUALS"
+      value     = ["my-container"]
+      key = “name”
+   }
+  }
+}
+```
+# Machine Resource Groups
+
+## Older Resource Group
+
+The older Machine resource group supported the machine tags field.
+
+### Example Representation
+
+```hcl
+resource "lacework_resource_group_machine" "example" {
+  name        = "My Machine Resource Group"
+  description = "This groups a subset of Machine Tags"
+  machine_tags {
+    key   = "name"
+    value = "myMachine"
+  }
+}
+```
+
+## Newer Resource Group
+
+The new resource group representation for the resource group above would support an expression
+tree structure in which the field key in the filter objects would be called Machine Tag and the 
+value key would be a list containing the values.
+
+### Example Representation
+
+```hcl
+resource "lacework_resource_group_machine" "example" {
+  name        = "My Machine Resource Group"
+  type        = "MACHINE"
+  description = "This groups a subset of Machine Tags"
+  group {
+    operator = "AND"
+    filter {
+      filter_name = "filter1"
+      field     = "Machine Tag"
+      operation = "EQUALS"
+      value     = ["myMachine"]
+      key       = “name”
+    }
+  }
+}
+```

--- a/docs/resources/convert_v1_to_v2_resource_groups.md
+++ b/docs/resources/convert_v1_to_v2_resource_groups.md
@@ -1,32 +1,27 @@
----
-subcategory: "Resource Groups"
-layout: "lacework"
-page_title: "Lacework: convert_to_newer_resource_group"
-description: |-
-  Converts old to new resource groups
----
-
-# convert_to_newer_resource_group
+# Convert Original To Newer Resource Groups
 
 The new version of Resource Groups changes the Terraform syntax used to create resource groups. 
-The old version of Resource Groups defined specific filter fields for each of the Resource Group 
+The original version of Resource Groups defined specific filter fields for each of the Resource Group 
 types. The new version defines the `group` argument as an expression tree representing the 
 relationships between resources.
 
-Refer to [Filterable Fields section]https://docs.fortinet.com/document/lacework-forticnapp/latest/api-reference/690087/using-the-resource-groups-api
+Refer to [Filterable Fields section](https://docs.fortinet.com/document/lacework-forticnapp/latest/api-reference/690087/using-the-resource-groups-api
 ) of the Lacework API documentation for supported resource group filters.
 
-**Note**: The following examples illustrate some common Resource Group types. Additional Resource Group types may apply to your environment and these examples can be used to determine the converted format for those Resource Group types. 
+**Note**: The following examples illustrate some common Resource Group types and fields. Additional 
+Resource Group types and filter fields may apply to your environment and these examples along 
+with the Filterable Fields section document link above can be used to determine the converted format. 
 
-# Lacework Account Resource Group
+# Lacework Account Resource Groups
 
-There is no new version for Lacework account (organization-level) resource groups. No conversion is applicable.
+Organizational level resource groups are deprecated and not supported.
 
 # AWS Resource Groups
 
-## Old Resource Groups
+## Original Resource Groups
 
-For AWS, old Resource Groups supported the `accounts` list field, which contained the accounts to be included in the resource group. If any of the accounts in the resource group matched an entry in the list, the resource group would be applied.
+For AWS, the original Resource Groups supported the `accounts` list field, which contained the 
+accounts to be included in the resource group. If any of the accounts in the resource group matched an entry in the list, the resource group would be applied.
 
 ### Example
 
@@ -40,7 +35,7 @@ resource "lacework_resource_group_aws" "example" {
 
 ## New Resource Groups
 
-New Resource Groups supports an expression tree structure in which the `field` field in a filter object is `Account` and the `value` field contains a list of the account IDs.
+The new Resource Groups support an expression tree structure in which the `field` field in a filter object is `Account` and the `value` field contains a list of the account IDs.
 
 ### Example
 
@@ -63,9 +58,11 @@ resource "lacework_resource_group" "example" {
 
 # Azure Resource Groups
 
-## Old Resource Groups
+## Original Resource Groups
 
-For Azure, the old Resource Groups supported the `tenant` field, which contained a list of subscriptions to be included in the Resource Group.
+For Azure, the original Resource Groups supported the `tenant` field, which 
+contained a list of subscriptions using the `subscriptions` field to be included in the Resource 
+Group.
 
 ### Example
 
@@ -80,12 +77,12 @@ resource "lacework_resource_group_azure" "example" {
 
 ## New Resource Groups
 
-The new Resource Groups supports an expression tree structure in which the `field` field in a filter object is defined as either `Tenant ID` or `Subscription ID` and the `value` field contains a list of the tenant or subscrption IDs.
+The new Resource Groups support an expression tree structure in which the `field` field in a filter object is defined as either `Tenant ID` or `Subscription ID` and the `value` field contains a list of the tenant or subscrption IDs.
 
 ### Example
 
 ```hcl
-resource "lacework_resource_group_azure" "example" {
+resource "lacework_resource_group" "example" {
   name        = "My Azure Resource Group"
   type        = "AZURE"
   description = "This groups a subset of Azure Subscriptions"
@@ -112,9 +109,9 @@ resource "lacework_resource_group_azure" "example" {
 
 # GCP Resource Groups
 
-## Old Resource Groups
+## Original Resource Groups
 
-For GCP, the old Resource Groups supported the `projects` field which contained a list of projects to be included in the resource group.
+For GCP, the original Resource Groups supported the `projects` field which contained a list of projects to be included in the resource group.
 
 ### Example
 
@@ -129,12 +126,12 @@ resource "lacework_resource_group_gcp" "example" {
 
 ## New Resource Groups
 
-The new Resource Groups supports an expression tree structure in which the `field` field in a filter object is defined as either `Organization ID` or `Project ID` and the `value` field contains a list of the organization or project IDs.
+The new Resource Groups support an expression tree structure in which the `field` field in a filter object is defined as either `Organization ID` or `Project ID` and the `value` field contains a list of the organization or project IDs.
 
 ### Example
 
 ```hcl
-resource "lacework_resource_group_gcp" "example" {
+resource "lacework_resource_group" "example" {
   name        = "My GCP Resource Group"
   type        = "GCP"
   description = "This groups a subset of Gcp Projects"
@@ -158,9 +155,9 @@ resource "lacework_resource_group_gcp" "example" {
 
 # Container Resource Groups
 
-## Old Resource Groups
+## Original Resource Groups
 
-For containers, the old Resource Groups supported the `container_tags` and `container_label` fields.
+For containers, the original Resource Groups supported the `container_tags` and `container_label` fields.
 
 ### Example
 
@@ -178,12 +175,12 @@ resource "lacework_resource_group_container" "example" {
 
 ## New Resource Groups
 
-The new Resource Groups supports an expression tree structure in which the `field` field in a filter object is defined as either `Image Tag` or `Container Label` and the `value` field contains a list of the image tags or container labels.
+The new Resource Groups support an expression tree structure in which the `field` field in a filter object is defined as either `Image Tag` or `Container Label` and the `value` field contains a list of the image tags or container labels.
 
 ### Example Representation
 
 ```hcl
-resource "lacework_resource_group_container" "example" {
+resource "lacework_resource_group" "example" {
   name        = "My Container Resource Group"
   type        = "CONTAINER"
   description = "This groups a subset of Container Tags"
@@ -200,7 +197,7 @@ resource "lacework_resource_group_container" "example" {
       field     = "Container Label"
       operation = "EQUALS"
       value     = ["my-container"]
-      key = “name”
+      key = "name"
    }
   }
 }
@@ -208,9 +205,9 @@ resource "lacework_resource_group_container" "example" {
 
 # Machine Resource Groups
 
-## Old Resource Groups
+## Original Resource Groups
 
-For machines, the old Resource Groups supported the `machine_tags` field.
+For machines, the original Resource Groups supported the `machine_tags` field.
 
 ### Example
 
@@ -226,14 +223,13 @@ resource "lacework_resource_group_machine" "example" {
 ```
 
 ## New Resource Groups
- new Resource Groups supports an expression tree structure in which the `field` field in a filter object is defined as either `Image Tag` or `Container Label` and the `value` field contains a list of the image tags or container labels.
  
-The new Resource Groups supports an expression tree structure in which the `field` field in a filter object is defined as `Machine Tag` and the `value` field contains a list of the machine tags.
+The new Resource Groups support an expression tree structure in which the `field` field in a filter object is defined as `Machine Tag` and the `value` field contains a list of the machine tags.
 
 ### Example
 
 ```hcl
-resource "lacework_resource_group_machine" "example" {
+resource "lacework_resource_group" "example" {
   name        = "My Machine Resource Group"
   type        = "MACHINE"
   description = "This groups a subset of Machine Tags"
@@ -244,7 +240,7 @@ resource "lacework_resource_group_machine" "example" {
       field     = "Machine Tag"
       operation = "EQUALS"
       value     = ["myMachine"]
-      key       = “name”
+      key       = "name"
     }
   }
 }

--- a/docs/resources/convert_v1_to_v2_resource_groups.md
+++ b/docs/resources/convert_v1_to_v2_resource_groups.md
@@ -3,48 +3,44 @@ subcategory: "Resource Groups"
 layout: "lacework"
 page_title: "Lacework: convert_to_newer_resource_group"
 description: |-
-  Converts V1 to V2 resource groups
+  Converts old to new resource groups
 ---
 
 # convert_to_newer_resource_group
 
-The new version of resource groups changes the Terraform syntax used to create the resource groups. 
-The older version of resource groups defined specific filter fields for each of the resource group 
-types. The newer version defines a group argument for an expression tree representing the 
+The new version of Resource Groups changes the Terraform syntax used to create resource groups. 
+The old version of Resource Groups defined specific filter fields for each of the Resource Group 
+types. The new version defines the `group` argument as an expression tree representing the 
 relationships between resources.
 
-Refer to Filterable Fields section [here](https://docs.fortinet.com/document/lacework-forticnapp/latest/api-reference/690087/using-the-resource-groups-api
-) for supported resource group filters
+Refer to [Filterable Fields section]https://docs.fortinet.com/document/lacework-forticnapp/latest/api-reference/690087/using-the-resource-groups-api
+) of the Lacework API documentation for supported resource group filters.
 
-# Lacework Account Resource Groups
+# Lacework Account Resource Group
 
-There is no new version for lacework account resource groups so no conversion is applicable for 
-these organizational level resource groups.
+There is no new version for Lacework account (organization-level) resource groups. No conversion is applicable.
 
 # AWS Resource Groups
 
-## Older Resource Group
+## Old Resource Groups
 
-The older AWS resource group supported the accounts list field to consist of the accounts to be
-included in the resource group. If any of the accounts in the resource group matched an entry in the
-list, the resource group would be applied.
+For AWS, old Resource Groups supported the `accounts` list field, which contained the accounts to be included in the resource group. If any of the accounts in the resource group matched an entry in the list, the resource group would be applied.
 
-### Example Representation
+### Example
 
 ```hcl
 resource "lacework_resource_group_aws" "example" {
-      name        = "My AWS Resource Group"
-      description = "This groups a subset of AWS Accounts"
-      accounts    = ["123456789", "234567891"]
+  name        = "My AWS Resource Group"
+  description = "A subset of AWS Accounts"
+  accounts    = ["123456789", "234567891"]
 }
 ```
 
-## Newer Resource Group
+## New Resource Groups
 
-The new resource group supports an expression tree structure in which the field key in the filter
-object would be called Account and the value key would be a list containing the values.
+New Resource Groups supports an expression tree structure in which the `field` field in a filter object is `Account` and the `value` field contains a list of the account IDs.
 
-### Example Representation
+### Example
 
 ```hcl
 resource "lacework_resource_group" "example" {
@@ -65,12 +61,11 @@ resource "lacework_resource_group" "example" {
 
 # Azure Resource Groups
 
-## Older Resource Group
+## Old Resource Groups
 
-The older Azure resource group supported the tenant field and a list of subscriptions within that 
-tenant to be included in the resource group.
+For Azure, the old Resource Groups supported the `tenant` field, which contained a list of subscriptions to be included in the Resource Group.
 
-### Example Representation
+### Example
 
 ```hcl
 resource "lacework_resource_group_azure" "example" {
@@ -81,13 +76,11 @@ resource "lacework_resource_group_azure" "example" {
 }
 ```
 
-## Newer Resource Group
+## New Resource Groups
 
-The new resource group representation for the resource group above would support an expression 
-tree structure in which the field key in the filter objects would be called either Tenant ID or Subscription ID and the value key would be a list 
-containing the values.
+The new Resource Groups supports an expression tree structure in which the `field` field in a filter object is defined as either `Tenant ID` or `Subscription ID` and the `value` field contains a list of the tenant or subscrption IDs.
 
-### Example Representation
+### Example
 
 ```hcl
 resource "lacework_resource_group_azure" "example" {
@@ -98,7 +91,7 @@ resource "lacework_resource_group_azure" "example" {
     operator = "AND"
     filter {
       filter_name = "filter1"
-      field     = "Tenant"
+      field     = "Tenant ID"
       operation = "EQUALS"
       value     = ["a11aa1ab-111a-11ab-a000-11aa1111a11a"]
     }
@@ -117,12 +110,11 @@ resource "lacework_resource_group_azure" "example" {
 
 # GCP Resource Groups
 
-## Older Resource Group
+## Old Resource Groups
 
-The older GCP resource group supported the organization field and a list of projects within that 
-organization to be included in the resource group.
+For GCP, the old Resource Groups supported the `projects` field which contained a list of projects to be included in the resource group.
 
-### Example Representation
+### Example
 
 ```hcl
 resource "lacework_resource_group_gcp" "example" {
@@ -133,13 +125,11 @@ resource "lacework_resource_group_gcp" "example" {
 }
 ```
 
-## Newer Resource Group
+## New Resource Groups
 
-The new resource group representation for the resource group above would support an expression
-tree structure in which the field key in the filter objects would be called either Organization 
-ID or Project ID and the value key would be a list containing the values.
+The new Resource Groups supports an expression tree structure in which the `field` field in a filter object is defined as either `Organization ID` or `Project ID` and the `value` field contains a list of the organization or project IDs.
 
-### Example Representation
+### Example
 
 ```hcl
 resource "lacework_resource_group_gcp" "example" {
@@ -166,11 +156,11 @@ resource "lacework_resource_group_gcp" "example" {
 
 # Container Resource Groups
 
-## Older Resource Group
+## Old Resource Groups
 
-The older Container resource group supported the fields container tags and labels.
+For containers, the old Resource Groups supported the `container_tags` and `container_label` fields.
 
-### Example Representation
+### Example
 
 ```hcl
 resource "lacework_resource_group_container" "example" {
@@ -184,11 +174,9 @@ resource "lacework_resource_group_container" "example" {
 }
 ```
 
-## Newer Resource Group
+## New Resource Groups
 
-The new resource group representation for the resource group above would support an expression
-tree structure in which the field key in the filter objects would be called either Image Tag or 
-Container Label and the value key would be a list containing the values.
+The new Resource Groups supports an expression tree structure in which the `field` field in a filter object is defined as either `Image Tag` or `Container Label` and the `value` field contains a list of the image tags or container labels.
 
 ### Example Representation
 
@@ -215,13 +203,14 @@ resource "lacework_resource_group_container" "example" {
   }
 }
 ```
+
 # Machine Resource Groups
 
-## Older Resource Group
+## Old Resource Groups
 
-The older Machine resource group supported the machine tags field.
+For machines, the old Resource Groups supported the `machine_tags` field.
 
-### Example Representation
+### Example
 
 ```hcl
 resource "lacework_resource_group_machine" "example" {
@@ -234,13 +223,12 @@ resource "lacework_resource_group_machine" "example" {
 }
 ```
 
-## Newer Resource Group
+## New Resource Groups
+ new Resource Groups supports an expression tree structure in which the `field` field in a filter object is defined as either `Image Tag` or `Container Label` and the `value` field contains a list of the image tags or container labels.
+ 
+The new Resource Groups supports an expression tree structure in which the `field` field in a filter object is defined as `Machine Tag` and the `value` field contains a list of the machine tags.
 
-The new resource group representation for the resource group above would support an expression
-tree structure in which the field key in the filter objects would be called Machine Tag and the 
-value key would be a list containing the values.
-
-### Example Representation
+### Example
 
 ```hcl
 resource "lacework_resource_group_machine" "example" {

--- a/docs/resources/convert_v1_to_v2_resource_groups.md
+++ b/docs/resources/convert_v1_to_v2_resource_groups.md
@@ -16,6 +16,8 @@ relationships between resources.
 Refer to [Filterable Fields section]https://docs.fortinet.com/document/lacework-forticnapp/latest/api-reference/690087/using-the-resource-groups-api
 ) of the Lacework API documentation for supported resource group filters.
 
+**Note**: The following examples illustrate some common Resource Group types. Additional Resource Group types may apply to your environment and these examples can be used to determine the converted format for those Resource Group types. 
+
 # Lacework Account Resource Group
 
 There is no new version for Lacework account (organization-level) resource groups. No conversion is applicable.

--- a/docs/resources/resource_group.md
+++ b/docs/resources/resource_group.md
@@ -11,6 +11,10 @@ description: |-
 Use this resource to create a Resource Group in order to categorize Lacework-identifiable assets.
 For more information, see the [Resource Groups documentation](https://docs.fortinet.com/document/lacework-forticnapp/latest/api-reference/690087/using-the-resource-groups-api).
 
+## Converting Original to Newer Resource Groups
+
+Please refer to this [documentation](convert_v1_to_v2_resource_groups.md) to understand how to
+convert the original resource groups to the newer resource groups.
 
 ## Example Usage
 

--- a/docs/resources/resource_group.md
+++ b/docs/resources/resource_group.md
@@ -13,7 +13,7 @@ For more information, see the [Resource Groups documentation](https://docs.forti
 
 ## Converting Original to Newer Resource Groups
 
-Please refer to this [documentation](convert_v1_to_v2_resource_groups.md) to understand how to
+Please refer to this [documentation](https://docs.fortinet.com/document/lacework-forticnapp/latest/api-reference/375795/convert-original-to-newer-resource-groups-in-terraform) to understand how to
 convert the original resource groups to the newer resource groups.
 
 ## Example Usage

--- a/integration/resource_lacework_alert_rule_test.go
+++ b/integration/resource_lacework_alert_rule_test.go
@@ -1,227 +1,237 @@
 package integration
 
+import (
+	"testing"
+
+	"fmt"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/lacework/go-sdk/v2/api"
+	"github.com/stretchr/testify/assert"
+	"time"
+)
+
 // TestAlertRuleCreate applies integration terraform:
 // => '../examples/resource_lacework_alert_rule'
 //
 // It uses the go-sdk to verify the created alert rule,
 // applies an update and destroys it
-//func TestAlertRuleCreate(t *testing.T) {
-//	name := fmt.Sprintf("Alert Rule - %s", time.Now())
-//	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-//		TerraformDir: "../examples/resource_lacework_alert_rule/current",
-//		EnvVars:      tokenEnvVar,
-//		Vars: map[string]interface{}{
-//			"name":                name,
-//			"description":         "Alert Rule created by Terraform",
-//			"channels":            []string{"TECHALLY_013F08F1B3FA97E7D54463DECAEEACF9AEA3AEACF863F76"},
-//			"severities":          []string{"Critical"},
-//			"alert_subcategories": []string{"Compliance"},
-//			"resource_group_name": fmt.Sprintf("Used for Alert Rule Test - %s", time.Now()),
-//		},
-//	})
-//	defer terraform.Destroy(t, terraformOptions)
-//
-//	terraformOptions.TimeBetweenRetries = 2 * time.Second
-//	// Create new Alert Rule
-//	create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
-//	createProps := GetAlertRuleProps(create)
-//
-//	actualName := terraform.Output(t, terraformOptions, "name")
-//	actualDescription := terraform.Output(t, terraformOptions, "description")
-//	actualChannels := terraform.Output(t, terraformOptions, "channels")
-//	actualSeverities := terraform.Output(t, terraformOptions, "severities")
-//	actualEventCategories := terraform.Output(t, terraformOptions, "alert_subcategories")
-//	actualResourceGroupID := terraform.Output(t, terraformOptions, "resource_group_id")
-//
-//	assert.Equal(t, "Alert Rule created by Terraform", createProps.Data.Filter.Description)
-//	assert.Equal(t, []string{"TECHALLY_013F08F1B3FA97E7D54463DECAEEACF9AEA3AEACF863F76"}, createProps.Data.Channels)
-//	assert.Equal(t, []string{"Critical"}, api.NewAlertRuleSeveritiesFromIntSlice(createProps.Data.Filter.Severity).ToStringSlice())
-//	assert.Equal(t, []string{actualResourceGroupID}, createProps.Data.Filter.ResourceGroups)
-//	assert.Equal(t, []string{"Compliance"}, createProps.Data.Filter.AlertSubCategories)
-//
-//	assert.Equal(t, name, actualName)
-//	assert.Equal(t, "Alert Rule created by Terraform", actualDescription)
-//	assert.Equal(t, "[TECHALLY_013F08F1B3FA97E7D54463DECAEEACF9AEA3AEACF863F76]", actualChannels)
-//	assert.Equal(t, string("[Critical]"), actualSeverities)
-//	assert.Equal(t, "[Compliance]", actualEventCategories)
-//
-//	// Update Alert Rule
-//	terraformOptions.Vars = map[string]interface{}{
-//		"name":        name,
-//		"description": "Updated Alert Rule created by Terraform",
-//		"channels": []string{"TECHALLY_01BA9DCAF34B654254D6BF92E5C24023951C3F812B07527",
-//			"TECHALLY_013F08F1B3FA97E7D54463DECAEEACF9AEA3AEACF863F76"},
-//		"severities":          []string{"High", "Medium"},
-//		"alert_subcategories": []string{"Compliance", "User", "Platform"},
-//		"resource_group_name": fmt.Sprintf("Used for Alert Rule Test - %s", time.Now()),
-//	}
-//
-//	update := terraform.ApplyAndIdempotent(t, terraformOptions)
-//	updateProps := GetAlertRuleProps(update)
-//	actualDescription = terraform.Output(t, terraformOptions, "description")
-//	actualChannels = terraform.Output(t, terraformOptions, "channels")
-//	actualSeverities = terraform.Output(t, terraformOptions, "severities")
-//	actualEventCategories = terraform.Output(t, terraformOptions, "alert_subcategories")
-//	actualResourceGroupID = terraform.Output(t, terraformOptions, "resource_group_id")
-//
-//	assert.Equal(t, "Updated Alert Rule created by Terraform", updateProps.Data.Filter.Description)
-//	assert.Contains(t, updateProps.Data.Channels, "TECHALLY_01BA9DCAF34B654254D6BF92E5C24023951C3F812B07527")
-//	assert.Contains(t, updateProps.Data.Channels, "TECHALLY_013F08F1B3FA97E7D54463DECAEEACF9AEA3AEACF863F76")
-//	assert.Equal(t, []string{"High", "Medium"}, api.NewAlertRuleSeveritiesFromIntSlice(updateProps.Data.Filter.Severity).ToStringSlice())
-//	assert.Equal(t, []string{actualResourceGroupID}, updateProps.Data.Filter.ResourceGroups)
-//	assert.ElementsMatch(t, []string{"Compliance", "User", "Platform"}, updateProps.Data.Filter.AlertSubCategories)
-//	assert.Equal(t, "Updated Alert Rule created by Terraform", actualDescription)
-//	assert.Equal(t, "[TECHALLY_013F08F1B3FA97E7D54463DECAEEACF9AEA3AEACF863F76 TECHALLY_01BA9DCAF34B654254D6BF92E5C24023951C3F812B07527]",
-//		actualChannels)
-//	assert.Equal(t, "[High Medium]", actualSeverities)
-//	assert.Equal(t, "[Compliance Platform User]", actualEventCategories)
-//}
+func TestAlertRuleCreate(t *testing.T) {
+	name := fmt.Sprintf("Alert Rule - %s", time.Now())
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/resource_lacework_alert_rule/current",
+		EnvVars:      tokenEnvVar,
+		Vars: map[string]interface{}{
+			"name":                name,
+			"description":         "Alert Rule created by Terraform",
+			"channels":            []string{"TECHALLY_013F08F1B3FA97E7D54463DECAEEACF9AEA3AEACF863F76"},
+			"severities":          []string{"Critical"},
+			"alert_subcategories": []string{"Compliance"},
+			"resource_group_name": fmt.Sprintf("Used for Alert Rule Test - %s", time.Now()),
+		},
+	})
+	defer terraform.Destroy(t, terraformOptions)
 
-//func TestAlertRuleSeverities(t *testing.T) {
-//	name := fmt.Sprintf("Alert Rule - %s", time.Now())
-//	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-//		TerraformDir: "../examples/resource_lacework_alert_rule/current",
-//		EnvVars:      tokenEnvVar,
-//		Vars: map[string]interface{}{
-//			"name":                name,
-//			"severities":          []string{"Critical", "high", "mEdIuM", "LOW"},
-//			"resource_group_name": fmt.Sprintf("Used for Alert Rule Test - %s", time.Now()),
-//		},
-//	})
-//	defer terraform.Destroy(t, terraformOptions)
-//
-//	terraformOptions.TimeBetweenRetries = 2 * time.Second
-//	create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
-//	createProps := GetAlertRuleProps(create)
-//
-//	actualSeverities := terraform.Output(t, terraformOptions, "severities")
-//
-//	assert.Equal(t,
-//		[]string{"Critical", "High", "Medium", "Low"},
-//		api.NewAlertRuleSeveritiesFromIntSlice(createProps.Data.Filter.Severity).ToStringSlice(),
-//	)
-//	assert.Equal(t, "[Critical High Medium Low]", actualSeverities)
-//
-//	invalidOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-//		TerraformDir: "../examples/resource_lacework_alert_rule/current",
-//		Vars: map[string]interface{}{
-//			"name":                name,
-//			"severities":          []string{"INVALID"},
-//			"resource_group_name": fmt.Sprintf("Used for Alert Rule Test - %s", time.Now()),
-//		},
-//	})
-//
-//	_, err := terraform.ApplyE(t, invalidOptions)
-//	if assert.Error(t, err) {
-//		assert.Contains(t,
-//			err.Error(),
-//			"severities.0: can only be 'Critical', 'High', 'Medium', 'Low', 'Info'",
-//		)
-//	}
-//}
-//
-//func TestAlertRuleCategories(t *testing.T) {
-//	name := fmt.Sprintf("Alert Rule - %s", time.Now())
-//	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-//		TerraformDir: "../examples/resource_lacework_alert_rule/current",
-//		EnvVars:      tokenEnvVar,
-//		Vars: map[string]interface{}{
-//			"name": name,
-//			"alert_subcategories": []string{
-//				"Compliance", "Application", "Cloud Activity", "File", "Machine",
-//				"User", "Platform", "Kubernetes Activity", "Registry", "SystemCall", "Host Vulnerability",
-//				"Container Vulnerability", "Threat Intel",
-//			},
-//			"alert_categories":    []string{"Policy"},
-//			"alert_sources":       []string{"AWS", "Agent"},
-//			"resource_group_name": fmt.Sprintf("Used for Alert Rule Test - %s", time.Now()),
-//		},
-//	})
-//	defer terraform.Destroy(t, terraformOptions)
-//
-//	terraformOptions.TimeBetweenRetries = 2 * time.Second
-//	create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
-//	createProps := GetAlertRuleProps(create)
-//
-//	actualCategories := terraform.Output(t, terraformOptions, "alert_subcategories")
-//	actualAlertCategories := terraform.Output(t, terraformOptions, "alert_categories")
-//	actualAlertSources := terraform.Output(t, terraformOptions, "alert_sources")
-//
-//	assert.ElementsMatch(t, []string{
-//		"Compliance", "Application", "Cloud Activity", "File", "Machine",
-//		"User", "Platform", "Kubernetes Activity", "Registry", "SystemCall", "Host Vulnerability",
-//		"Container Vulnerability", "Threat Intel",
-//	}, createProps.Data.Filter.AlertSubCategories)
-//	assert.ElementsMatch(t, []string{"AWS", "Agent"}, createProps.Data.Filter.AlertSources)
-//	assert.ElementsMatch(t, []string{"Policy"}, createProps.Data.Filter.AlertCategories)
-//
-//	assert.Equal(t, "[Application Cloud Activity Compliance Container Vulnerability File Host Vulnerability Kubernetes Activity Machine Platform Registry SystemCall Threat Intel User]",
-//		actualCategories)
-//	assert.Equal(t, "[AWS Agent]", actualAlertSources)
-//	assert.Equal(t, "[Policy]", actualAlertCategories)
-//
-//	invalidOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-//		TerraformDir: "../examples/resource_lacework_alert_rule/current",
-//		Vars: map[string]interface{}{
-//			"name":                name,
-//			"alert_subcategories": []string{"INVALID"},
-//			"resource_group_name": fmt.Sprintf("Used for Alert Rule Test - %s", time.Now()),
-//		},
-//	})
-//
-//	_, err := terraform.ApplyE(t, invalidOptions)
-//	if assert.Error(t, err) {
-//		assert.Contains(t,
-//			err.Error(),
-//			"expected alert_subcategories.0 to be one of [Compliance Application Cloud Activity File Machine User Platform Kubernetes Activity Registry SystemCall Host Vulnerability Container Vulnerability Threat Intel App Cloud K8sActivity]",
-//		)
-//	}
-//}
-//
-//func TestAlertRuleDeprecatedEventCategories(t *testing.T) {
-//	name := fmt.Sprintf("Alert Rule - %s", time.Now())
-//	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-//		TerraformDir: "../examples/resource_lacework_alert_rule/deprecated",
-//		EnvVars:      tokenEnvVar,
-//		Vars: map[string]interface{}{
-//			"name": name,
-//			"event_categories": []string{"Compliance", "App", "Cloud", "File", "Machine",
-//				"User", "Platform", "K8sActivity", "Registry", "SystemCall"},
-//			"alert_categories":    []string{"Policy"},
-//			"resource_group_name": fmt.Sprintf("Used for Alert Rule Test - %s", time.Now()),
-//		},
-//	})
-//	defer terraform.Destroy(t, terraformOptions)
-//
-//	terraformOptions.TimeBetweenRetries = 2 * time.Second
-//	create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
-//	createProps := GetAlertRuleProps(create)
-//
-//	actualCategories := terraform.Output(t, terraformOptions, "event_categories")
-//	actualAlertCategories := terraform.Output(t, terraformOptions, "alert_categories")
-//
-//	// assert.ElementsMatch(t, []string{"Compliance", "App", "Cloud", "File", "Machine",
-//	// 	"User", "Platform", "K8sActivity", "Registry", "SystemCall"}, createProps.Data.Filter.AlertSubCategories)
-//	assert.ElementsMatch(t, []string{"Policy"}, createProps.Data.Filter.AlertCategories)
-//
-//	assert.Equal(t, "[App Cloud Compliance File K8sActivity Machine Platform Registry SystemCall User]",
-//		actualCategories)
-//	assert.Equal(t, "[Policy]", actualAlertCategories)
-//
-//	invalidOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-//		TerraformDir: "../examples/resource_lacework_alert_rule/deprecated",
-//		Vars: map[string]interface{}{
-//			"name":                name,
-//			"event_categories":    []string{"INVALID"},
-//			"resource_group_name": fmt.Sprintf("Used for Alert Rule Test - %s", time.Now()),
-//		},
-//	})
-//
-//	_, err := terraform.ApplyE(t, invalidOptions)
-//	if assert.Error(t, err) {
-//		assert.Contains(t,
-//			err.Error(),
-//			"expected event_categories.0 to be one of [Compliance Application Cloud Activity File Machine User Platform Kubernetes Activity Registry SystemCall Host Vulnerability Container Vulnerability Threat Intel App Cloud K8sActivity]",
-//		)
-//	}
-//}
+	terraformOptions.TimeBetweenRetries = 2 * time.Second
+	// Create new Alert Rule
+	create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+	createProps := GetAlertRuleProps(create)
+
+	actualName := terraform.Output(t, terraformOptions, "name")
+	actualDescription := terraform.Output(t, terraformOptions, "description")
+	actualChannels := terraform.Output(t, terraformOptions, "channels")
+	actualSeverities := terraform.Output(t, terraformOptions, "severities")
+	actualEventCategories := terraform.Output(t, terraformOptions, "alert_subcategories")
+	actualResourceGroupID := terraform.Output(t, terraformOptions, "resource_group_id")
+
+	assert.Equal(t, "Alert Rule created by Terraform", createProps.Data.Filter.Description)
+	assert.Equal(t, []string{"TECHALLY_013F08F1B3FA97E7D54463DECAEEACF9AEA3AEACF863F76"}, createProps.Data.Channels)
+	assert.Equal(t, []string{"Critical"}, api.NewAlertRuleSeveritiesFromIntSlice(createProps.Data.Filter.Severity).ToStringSlice())
+	assert.Equal(t, []string{actualResourceGroupID}, createProps.Data.Filter.ResourceGroups)
+	assert.Equal(t, []string{"Compliance"}, createProps.Data.Filter.AlertSubCategories)
+
+	assert.Equal(t, name, actualName)
+	assert.Equal(t, "Alert Rule created by Terraform", actualDescription)
+	assert.Equal(t, "[TECHALLY_013F08F1B3FA97E7D54463DECAEEACF9AEA3AEACF863F76]", actualChannels)
+	assert.Equal(t, string("[Critical]"), actualSeverities)
+	assert.Equal(t, "[Compliance]", actualEventCategories)
+
+	// Update Alert Rule
+	terraformOptions.Vars = map[string]interface{}{
+		"name":        name,
+		"description": "Updated Alert Rule created by Terraform",
+		"channels": []string{"TECHALLY_01BA9DCAF34B654254D6BF92E5C24023951C3F812B07527",
+			"TECHALLY_013F08F1B3FA97E7D54463DECAEEACF9AEA3AEACF863F76"},
+		"severities":          []string{"High", "Medium"},
+		"alert_subcategories": []string{"Compliance", "User", "Platform"},
+		"resource_group_name": fmt.Sprintf("Used for Alert Rule Test - %s", time.Now()),
+	}
+
+	update := terraform.ApplyAndIdempotent(t, terraformOptions)
+	updateProps := GetAlertRuleProps(update)
+	actualDescription = terraform.Output(t, terraformOptions, "description")
+	actualChannels = terraform.Output(t, terraformOptions, "channels")
+	actualSeverities = terraform.Output(t, terraformOptions, "severities")
+	actualEventCategories = terraform.Output(t, terraformOptions, "alert_subcategories")
+	actualResourceGroupID = terraform.Output(t, terraformOptions, "resource_group_id")
+
+	assert.Equal(t, "Updated Alert Rule created by Terraform", updateProps.Data.Filter.Description)
+	assert.Contains(t, updateProps.Data.Channels, "TECHALLY_01BA9DCAF34B654254D6BF92E5C24023951C3F812B07527")
+	assert.Contains(t, updateProps.Data.Channels, "TECHALLY_013F08F1B3FA97E7D54463DECAEEACF9AEA3AEACF863F76")
+	assert.Equal(t, []string{"High", "Medium"}, api.NewAlertRuleSeveritiesFromIntSlice(updateProps.Data.Filter.Severity).ToStringSlice())
+	assert.Equal(t, []string{actualResourceGroupID}, updateProps.Data.Filter.ResourceGroups)
+	assert.ElementsMatch(t, []string{"Compliance", "User", "Platform"}, updateProps.Data.Filter.AlertSubCategories)
+	assert.Equal(t, "Updated Alert Rule created by Terraform", actualDescription)
+	assert.Equal(t, "[TECHALLY_013F08F1B3FA97E7D54463DECAEEACF9AEA3AEACF863F76 TECHALLY_01BA9DCAF34B654254D6BF92E5C24023951C3F812B07527]",
+		actualChannels)
+	assert.Equal(t, "[High Medium]", actualSeverities)
+	assert.Equal(t, "[Compliance Platform User]", actualEventCategories)
+}
+
+func TestAlertRuleSeverities(t *testing.T) {
+	name := fmt.Sprintf("Alert Rule - %s", time.Now())
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/resource_lacework_alert_rule/current",
+		EnvVars:      tokenEnvVar,
+		Vars: map[string]interface{}{
+			"name":                name,
+			"severities":          []string{"Critical", "high", "mEdIuM", "LOW"},
+			"resource_group_name": fmt.Sprintf("Used for Alert Rule Test - %s", time.Now()),
+		},
+	})
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraformOptions.TimeBetweenRetries = 2 * time.Second
+	create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+	createProps := GetAlertRuleProps(create)
+
+	actualSeverities := terraform.Output(t, terraformOptions, "severities")
+
+	assert.Equal(t,
+		[]string{"Critical", "High", "Medium", "Low"},
+		api.NewAlertRuleSeveritiesFromIntSlice(createProps.Data.Filter.Severity).ToStringSlice(),
+	)
+	assert.Equal(t, "[Critical High Medium Low]", actualSeverities)
+
+	invalidOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/resource_lacework_alert_rule/current",
+		Vars: map[string]interface{}{
+			"name":                name,
+			"severities":          []string{"INVALID"},
+			"resource_group_name": fmt.Sprintf("Used for Alert Rule Test - %s", time.Now()),
+		},
+	})
+
+	_, err := terraform.ApplyE(t, invalidOptions)
+	if assert.Error(t, err) {
+		assert.Contains(t,
+			err.Error(),
+			"severities.0: can only be 'Critical', 'High', 'Medium', 'Low', 'Info'",
+		)
+	}
+}
+
+func TestAlertRuleCategories(t *testing.T) {
+	name := fmt.Sprintf("Alert Rule - %s", time.Now())
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/resource_lacework_alert_rule/current",
+		EnvVars:      tokenEnvVar,
+		Vars: map[string]interface{}{
+			"name": name,
+			"alert_subcategories": []string{
+				"Compliance", "Application", "Cloud Activity", "File", "Machine",
+				"User", "Platform", "Kubernetes Activity", "Registry", "SystemCall", "Host Vulnerability",
+				"Container Vulnerability", "Threat Intel",
+			},
+			"alert_categories":    []string{"Policy"},
+			"alert_sources":       []string{"AWS", "Agent"},
+			"resource_group_name": fmt.Sprintf("Used for Alert Rule Test - %s", time.Now()),
+		},
+	})
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraformOptions.TimeBetweenRetries = 2 * time.Second
+	create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+	createProps := GetAlertRuleProps(create)
+
+	actualCategories := terraform.Output(t, terraformOptions, "alert_subcategories")
+	actualAlertCategories := terraform.Output(t, terraformOptions, "alert_categories")
+	actualAlertSources := terraform.Output(t, terraformOptions, "alert_sources")
+
+	assert.ElementsMatch(t, []string{
+		"Compliance", "Application", "Cloud Activity", "File", "Machine",
+		"User", "Platform", "Kubernetes Activity", "Registry", "SystemCall", "Host Vulnerability",
+		"Container Vulnerability", "Threat Intel",
+	}, createProps.Data.Filter.AlertSubCategories)
+	assert.ElementsMatch(t, []string{"AWS", "Agent"}, createProps.Data.Filter.AlertSources)
+	assert.ElementsMatch(t, []string{"Policy"}, createProps.Data.Filter.AlertCategories)
+
+	assert.Equal(t, "[Application Cloud Activity Compliance Container Vulnerability File Host Vulnerability Kubernetes Activity Machine Platform Registry SystemCall Threat Intel User]",
+		actualCategories)
+	assert.Equal(t, "[AWS Agent]", actualAlertSources)
+	assert.Equal(t, "[Policy]", actualAlertCategories)
+
+	invalidOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/resource_lacework_alert_rule/current",
+		Vars: map[string]interface{}{
+			"name":                name,
+			"alert_subcategories": []string{"INVALID"},
+			"resource_group_name": fmt.Sprintf("Used for Alert Rule Test - %s", time.Now()),
+		},
+	})
+
+	_, err := terraform.ApplyE(t, invalidOptions)
+	if assert.Error(t, err) {
+		assert.Contains(t,
+			err.Error(),
+			"expected alert_subcategories.0 to be one of [Compliance Application Cloud Activity File Machine User Platform Kubernetes Activity Registry SystemCall Host Vulnerability Container Vulnerability Threat Intel App Cloud K8sActivity]",
+		)
+	}
+}
+
+func TestAlertRuleDeprecatedEventCategories(t *testing.T) {
+	name := fmt.Sprintf("Alert Rule - %s", time.Now())
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/resource_lacework_alert_rule/deprecated",
+		EnvVars:      tokenEnvVar,
+		Vars: map[string]interface{}{
+			"name": name,
+			"event_categories": []string{"Compliance", "App", "Cloud", "File", "Machine",
+				"User", "Platform", "K8sActivity", "Registry", "SystemCall"},
+			"alert_categories":    []string{"Policy"},
+			"resource_group_name": fmt.Sprintf("Used for Alert Rule Test - %s", time.Now()),
+		},
+	})
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraformOptions.TimeBetweenRetries = 2 * time.Second
+	create := terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+	createProps := GetAlertRuleProps(create)
+
+	actualCategories := terraform.Output(t, terraformOptions, "event_categories")
+	actualAlertCategories := terraform.Output(t, terraformOptions, "alert_categories")
+
+	// assert.ElementsMatch(t, []string{"Compliance", "App", "Cloud", "File", "Machine",
+	// 	"User", "Platform", "K8sActivity", "Registry", "SystemCall"}, createProps.Data.Filter.AlertSubCategories)
+	assert.ElementsMatch(t, []string{"Policy"}, createProps.Data.Filter.AlertCategories)
+
+	assert.Equal(t, "[App Cloud Compliance File K8sActivity Machine Platform Registry SystemCall User]",
+		actualCategories)
+	assert.Equal(t, "[Policy]", actualAlertCategories)
+
+	invalidOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/resource_lacework_alert_rule/deprecated",
+		Vars: map[string]interface{}{
+			"name":                name,
+			"event_categories":    []string{"INVALID"},
+			"resource_group_name": fmt.Sprintf("Used for Alert Rule Test - %s", time.Now()),
+		},
+	})
+
+	_, err := terraform.ApplyE(t, invalidOptions)
+	if assert.Error(t, err) {
+		assert.Contains(t,
+			err.Error(),
+			"expected event_categories.0 to be one of [Compliance Application Cloud Activity File Machine User Platform Kubernetes Activity Registry SystemCall Host Vulnerability Container Vulnerability Threat Intel App Cloud K8sActivity]",
+		)
+	}
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-provider-lacework/blob/main/CONTRIBUTING.md
--->

***Issue***: https://lacework.atlassian.net/browse/CAD-822

***Description:***
This is the doc for detailing how to convert the V1 to V2 resource groups

***Test:***
New terraform V2 resource groups created successfully in qan environment. 
<img width="1500" alt="Screenshot 2024-11-05 at 2 35 07 PM" src="https://github.com/user-attachments/assets/76ff3053-004e-4639-aafa-5f7ade57c7e1">
<img width="1389" alt="Screenshot 2024-11-05 at 2 16 00 PM" src="https://github.com/user-attachments/assets/0141c315-4dbd-4e4c-9084-a18ee3f0e39d">
