### PR TITLE
fix: use correct Microsoft teams webhook URL in tests

### DIFF
--- a/docs/resources/alert_channel_microsoft_teams.md
+++ b/docs/resources/alert_channel_microsoft_teams.md
@@ -18,7 +18,7 @@ To find more information about the alert payload, see the [Lacework support docu
 ```hcl
 resource "lacework_alert_channel_microsoft_teams" "example" {
   name      = "Microsoft Teams Alerts"
-  webhook_url = "https://outlook.office.com/webhook/api-token"
+  webhook_url = "https://test-tenant.outlook.office.com/webhook/api-token"
 }
 ```
 

--- a/examples/resource_lacework_alert_channel_microsoft_teams/main.tf
+++ b/examples/resource_lacework_alert_channel_microsoft_teams/main.tf
@@ -32,7 +32,7 @@ variable "channel_name" {
 
 variable "webhook_url" {
   type    = string
-  default = "https://outlook.office.com/webhook/api-token"
+  default = "https://test-tenant.outlook.office.com/webhook/api-token"
 }
 
 output "channel_name" {

--- a/integration/resource_lacework_alert_channel_microsoft_teams_test.go
+++ b/integration/resource_lacework_alert_channel_microsoft_teams_test.go
@@ -18,7 +18,7 @@ func TestAlertChannelMicrosoftTeams(t *testing.T) {
 		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"channel_name": "Test Name",
-			"webhook_url":  "https://outlook.office.com/webhook/api-token",
+			"webhook_url":  "https://test-tenant.outlook.office.com/webhook/api-token",
 		},
 	})
 	defer terraform.Destroy(t, terraformOptions)
@@ -30,7 +30,7 @@ func TestAlertChannelMicrosoftTeams(t *testing.T) {
 	// Update Microsoft Teams Alert Channel
 	terraformOptions.Vars = map[string]interface{}{
 		"channel_name": "Updated Test Name",
-		"webhook_url":  "https://outlook.office.com/webhook/updated-api-token",
+		"webhook_url":  "https://test-tenant.outlook.office.com/webhook/updated-api-token",
 	}
 
 	update := terraform.Apply(t, terraformOptions)
@@ -40,12 +40,12 @@ func TestAlertChannelMicrosoftTeams(t *testing.T) {
 	if data, ok := updateProps.Data.Data.(map[string]interface{}); ok {
 		assert.True(t, ok)
 		assert.Equal(t, "Updated Test Name", updateProps.Data.Name)
-		assert.Equal(t, "https://outlook.office.com/webhook/updated-api-token", data["teamsUrl"])
+		assert.Equal(t, "https://test-tenant.outlook.office.com/webhook/updated-api-token", data["teamsUrl"])
 	}
 
 	// Verify that the terraform resource has the correct information as expected
 	actualChannelName := terraform.Output(t, terraformOptions, "channel_name")
 	actualWebhookUrl := terraform.Output(t, terraformOptions, "webhook_url")
 	assert.Equal(t, "Updated Test Name", actualChannelName)
-	assert.Equal(t, "https://outlook.office.com/webhook/updated-api-token", actualWebhookUrl)
+	assert.Equal(t, "https://test-tenant.outlook.office.com/webhook/updated-api-token", actualWebhookUrl)
 }

--- a/integration/rollback_alert_channel_test.go
+++ b/integration/rollback_alert_channel_test.go
@@ -16,7 +16,7 @@ func TestAlertChannelRollback(t *testing.T) {
 		EnvVars:      tokenEnvVar,
 		Vars: map[string]interface{}{
 			"channel_name":     "Test Name",
-			"webhook_url":      "https://outlook.office.com/webhook/api-token",
+			"webhook_url":      "https://test-tenant.outlook.office.com/webhook/api-token",
 			"test_integration": true,
 		},
 	})


### PR DESCRIPTION
### Description
- Use correct Microsoft teams webhook URL in tests
  - The teams webhook URL pattern was updated in https://github.com/lacework/services/commit/a9c98f1e8d2bbdbe5aa5fd3219bbecb2d0bc4aaf#diff-89e41363d2430e8f79e5c54d90c7f8266b1ed4bc8cafe7e2b2a9c11773c88712R3406