### PR TITLE
chore: deprecate alert_enabled for policy_compliance

### DIFF
--- a/docs/resources/policy_compliance.md
+++ b/docs/resources/policy_compliance.md
@@ -71,7 +71,7 @@ The following arguments are supported:
 * `enabled` - (Optional) Whether the policy is enabled or disabled. Defaults to `true`.
 * `policy_id_suffix` - (Optional) The string appended to the end of the policy id.
 * `tags` - (Optional) A list of policy tags.
-* `alerting_enabled` - (Optional) Whether the alerting profile is enabled or disabled. Defaults to `true`.
+* `alerting_enabled` - (Optional, **Deprecated**) Whether the alerting profile is enabled or disabled. Defaults to `true`.
 
 ## Import
 

--- a/lacework/resource_lacework_policy_compliance.go
+++ b/lacework/resource_lacework_policy_compliance.go
@@ -75,6 +75,7 @@ func resourceLaceworkPolicyCompliance() *schema.Resource {
 			"alerting_enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Deprecated:  "This attribute is deprecated. Alerting is always enabled for compliance policies.",
 				Default:     true,
 				Description: "Whether alerting is enabled or disabled",
 			},
@@ -118,7 +119,7 @@ func resourceLaceworkPolicyComplianceCreate(d *schema.ResourceData, meta interfa
 		Severity:     d.Get("severity").(string),
 		PolicyID:     d.Get("policy_id_suffix").(string),
 		Tags:         castStringSlice(d.Get("tags").(*schema.Set).List()),
-		AlertEnabled: d.Get("alerting_enabled").(bool),
+		AlertEnabled: true,
 	}
 
 	log.Printf("[INFO] Creating Policy with data:\n%+v\n", policy)


### PR DESCRIPTION
***Issue***: Include link to the Jira/Github Issue (REQUIRED)

https://lacework.atlassian.net/browse/LINK-3796

***Description:***
All compliance policies generate alerts. The `alert_enabled` flag is not used anywhere so should be deprecated
