### PR TITLE
chore: change GET method in Vulnerability Exception Container Read method.

### DIFF
--- a/lacework/resource_lacework_vulnerability_exception_container.go
+++ b/lacework/resource_lacework_vulnerability_exception_container.go
@@ -298,11 +298,10 @@ func resourceLaceworkVulnerabilityExceptionContainerCreate(d *schema.ResourceDat
 func resourceLaceworkVulnerabilityExceptionContainerRead(d *schema.ResourceData, meta interface{}) error {
 	var (
 		lacework = meta.(*api.Client)
-		response api.VulnerabilityExceptionResponse
 	)
 
 	log.Printf("[INFO] Reading vulnerability exception with guid %s\n", d.Id())
-	err := lacework.V2.VulnerabilityExceptions.Get(d.Id(), &response)
+	response, err := lacework.V2.VulnerabilityExceptions.GetVulnerabilityExceptionsContainer(d.Id())
 	if err != nil {
 		return resourceNotFound(d, err)
 	}


### PR DESCRIPTION
***Issue***:
https://lacework.atlassian.net/browse/LINK-4134
https://github.com/lacework/terraform-provider-lacework/issues/699

***Description:***
Terraform crashes when refreshing lacework_vulnerability_exception_container resources. The provider (terraform-provider-lacework) panics with a nil pointer dereference inside resourceLaceworkVulnerabilityExceptionContainerRead(). This causes Terraform to error with rpc error: code = Unavailable desc = transport is closing or Error: Plugin did not respond.

***Additional Info:***
**Why This Causes the Crash:**
1. **Generic Response Type**: VulnerabilityExceptionResponse has ResourceScope *VulnerabilityExceptionResourceScope (pointer, can be nil)
2. **Container Response Type**: VulnerabilityExceptionContainerResponse has ResourceScope VulnerabilityExceptionResourceScopeContainer (value, not pointer)

**Before fix: **
<img width="1390" height="858" alt="Screenshot 2025-09-22 at 10 03 19 AM" src="https://github.com/user-attachments/assets/dccbf4ce-bb13-44ff-9b99-fd70232fa2d4" />

**After fix: **
<img width="1390" height="653" alt="Screenshot 2025-09-22 at 10 06 30 AM" src="https://github.com/user-attachments/assets/1ce1017d-84d9-4939-8e3f-afc883d256c7" />

