### PR TITLE
fix(AWLS2-1027): DSPM integration_level property must be marked 'computed'

### DIFF
--- a/lacework/resource_lacework_aws_dspm.go
+++ b/lacework/resource_lacework_aws_dspm.go
@@ -72,7 +72,11 @@ func resourceLaceworkAwsDspm() *schema.Resource {
 			"integration_level": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  api.AwsAccountIntegration,
+				// Computed (not Default): a schema Default is applied to any config
+				// that omits the field, which would force an in-place update (PATCH)
+				// on integrations created before this attribute existed. The actual
+				// value is defaulted to ACCOUNT in Create/Update when unset.
+				Computed: true,
 				StateFunc: func(val interface{}) string {
 					return strings.ToUpper(val.(string))
 				},

--- a/lacework/resource_lacework_aws_dspm.go
+++ b/lacework/resource_lacework_aws_dspm.go
@@ -72,10 +72,6 @@ func resourceLaceworkAwsDspm() *schema.Resource {
 			"integration_level": {
 				Type:     schema.TypeString,
 				Optional: true,
-				// Computed (not Default): a schema Default is applied to any config
-				// that omits the field, which would force an in-place update (PATCH)
-				// on integrations created before this attribute existed. The actual
-				// value is defaulted to ACCOUNT in Create/Update when unset.
 				Computed: true,
 				StateFunc: func(val interface{}) string {
 					return strings.ToUpper(val.(string))

--- a/lacework/resource_lacework_azure_dspm.go
+++ b/lacework/resource_lacework_azure_dspm.go
@@ -39,10 +39,6 @@ func resourceLaceworkAzureDspm() *schema.Resource {
 			"integration_level": {
 				Type:     schema.TypeString,
 				Optional: true,
-				// Computed (not Default): a schema Default is applied to any config
-				// that omits the field, which would force an in-place update (PATCH)
-				// on integrations created before this attribute existed. The actual
-				// value is defaulted to SUBSCRIPTION in Create/Update when unset.
 				Computed: true,
 				StateFunc: func(val interface{}) string {
 					return strings.ToUpper(val.(string))

--- a/lacework/resource_lacework_azure_dspm.go
+++ b/lacework/resource_lacework_azure_dspm.go
@@ -39,7 +39,11 @@ func resourceLaceworkAzureDspm() *schema.Resource {
 			"integration_level": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  api.AzureSubscriptionIntegration,
+				// Computed (not Default): a schema Default is applied to any config
+				// that omits the field, which would force an in-place update (PATCH)
+				// on integrations created before this attribute existed. The actual
+				// value is defaulted to SUBSCRIPTION in Create/Update when unset.
+				Computed: true,
 				StateFunc: func(val interface{}) string {
 					return strings.ToUpper(val.(string))
 				},

--- a/lacework/resource_lacework_dspm_integration_level_test.go
+++ b/lacework/resource_lacework_dspm_integration_level_test.go
@@ -1,0 +1,87 @@
+package lacework
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression for the v2.4.0 phantom-PATCH: the DSPM integration_level attribute must be
+// Optional+Computed with NO schema Default. A schema Default is applied to any config that
+// omits the field, which forced an in-place update (PATCH) on every DSPM integration created
+// before this attribute existed (their state has an empty integration_level) — breaking
+// existing deployments on provider upgrade. Computed lets an omitted value track the backend
+// with no diff; the Create/Update code still defaults the value actually sent to the API.
+func TestDspmIntegrationLevel_SchemaHasNoDefault(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		res  *schema.Resource
+	}{
+		{"aws", resourceLaceworkAwsDspm()},
+		{"azure", resourceLaceworkAzureDspm()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := tc.res.Schema["integration_level"]
+			require.NotNil(t, s)
+			assert.Nil(t, s.Default, "integration_level must NOT have a schema Default (it forces a PATCH on pre-existing integrations)")
+			assert.True(t, s.Computed, "integration_level must be Computed so an omitted value tracks the backend")
+			assert.True(t, s.Optional, "integration_level must remain Optional")
+		})
+	}
+}
+
+// TestDspmIntegrationLevel_OmittedProducesNoDiff exercises the behavior the schema guards:
+// an existing integration (integration_level already empty in state) whose config omits
+// integration_level must plan NO change for that attribute — i.e. Terraform won't PATCH it
+// on upgrade.
+func TestDspmIntegrationLevel_OmittedProducesNoDiff(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		res    *schema.Resource
+		config map[string]interface{}
+	}{
+		{
+			"aws", resourceLaceworkAwsDspm(),
+			map[string]interface{}{
+				"name":               "existing",
+				"storage_bucket_arn": "arn:aws:s3:::bucket",
+				"regions":            []interface{}{"us-east-1"},
+				"credentials":        []interface{}{map[string]interface{}{"external_id": "x", "role_arn": "arn:aws:iam::123456789012:role/r"}},
+			},
+		},
+		{
+			"azure", resourceLaceworkAzureDspm(),
+			map[string]interface{}{
+				"name":                "existing",
+				"storage_account_url": "https://x.blob.core.windows.net/",
+				"blob_container_name": "c",
+				"regions":             []interface{}{"East US"},
+				"credentials":         []interface{}{map[string]interface{}{"client_id": "x", "client_secret": "y"}},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Simulate an integration created before integration_level existed: empty in state.
+			state := &terraform.InstanceState{
+				ID:         "existing-guid",
+				Attributes: map[string]string{"integration_level": ""},
+			}
+			cfg := terraform.NewResourceConfigRaw(tc.config)
+
+			diff, err := tc.res.Diff(context.Background(), state, cfg, nil)
+			require.NoError(t, err)
+
+			if diff != nil {
+				if d, ok := diff.Attributes["integration_level"]; ok {
+					assert.Falsef(t, d.New != d.Old || d.NewComputed,
+						"omitted integration_level must not plan a change (old=%q new=%q computed=%v)",
+						d.Old, d.New, d.NewComputed)
+				}
+			}
+		})
+	}
+}

--- a/lacework/resource_lacework_dspm_integration_level_test.go
+++ b/lacework/resource_lacework_dspm_integration_level_test.go
@@ -10,12 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Regression for the v2.4.0 phantom-PATCH: the DSPM integration_level attribute must be
-// Optional+Computed with NO schema Default. A schema Default is applied to any config that
-// omits the field, which forced an in-place update (PATCH) on every DSPM integration created
-// before this attribute existed (their state has an empty integration_level) — breaking
-// existing deployments on provider upgrade. Computed lets an omitted value track the backend
-// with no diff; the Create/Update code still defaults the value actually sent to the API.
 func TestDspmIntegrationLevel_SchemaHasNoDefault(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -34,10 +28,6 @@ func TestDspmIntegrationLevel_SchemaHasNoDefault(t *testing.T) {
 	}
 }
 
-// TestDspmIntegrationLevel_OmittedProducesNoDiff exercises the behavior the schema guards:
-// an existing integration (integration_level already empty in state) whose config omits
-// integration_level must plan NO change for that attribute — i.e. Terraform won't PATCH it
-// on upgrade.
 func TestDspmIntegrationLevel_OmittedProducesNoDiff(t *testing.T) {
 	for _, tc := range []struct {
 		name   string


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-provider-lacework/blob/main/CONTRIBUTING.md
--->

***Issue***: https://lacework.atlassian.net/browse/AWLS2-1027

***Description:***
We recently published an update of this provider with support for tenant (Azure) or organization (AWS) level DSPM integrations: 
https://github.com/lacework/terraform-provider-lacework/pull/726

After releasing that change, QA found an important flaw: the new `integration_level` property is marked `Required`, which in turn requires a patch to all existing DSPM integrations that don't have this property. To make matters worse, the iris validation for this DSPM schema update is not yet released -- so the patch inevitably fails.

The solution is to mark this field `Computed` instead. If it is not specified, the integration creation code will apply a default value of `ACCOUNT` or `SUBSCRIPTION` for this property anyways. 

I also added a quick unit test for this change.