### PR TITLE
ci: install Go toolchain from go.mod instead of pinning 1.21.x

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version-file: go.mod
 
       - name: Run Unit Tests
         id: unit
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version-file: go.mod
 
       - name: Build 
         id: build
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version-file: go.mod
 
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version-file: go.mod
 
       - name: Prepare release
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version-file: go.mod
 
       - name: Release
         shell: bash

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version-file: go.mod
 
       - name: Run Unit Tests
         id: unit
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version-file: go.mod
 
       - name: Build 
         id: build
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version-file: go.mod
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3
         with:


### PR DESCRIPTION
Fixes the red `run-unit-tests` check on every Dependabot PR that raises the `go` directive to 1.25 (#731, #733, #735, #737). **Merge this first** — the dependency PRs stacked behind it depend on it.

## The bug

All eight `actions/setup-go` steps pinned `go-version: 1.21.x` while `go.mod` declares `go 1.24.0`, so the go command bridged the gap by downloading a *module-cache* toolchain (`golang.org/toolchain@v0.0.1-goX.Y.Z`) at build time.

That breaks the moment `go.mod` moves to Go 1.25. Go 1.25 no longer ships a prebuilt `covdata`; it builds one on demand into `GOROOT`, which a module-cache toolchain cannot do because the module cache is read-only:

| toolchain | `pkg/tool` contents |
|---|---|
| module toolchain go1.24.x | `… covdata cover …` ✅ |
| module toolchain go1.25.x | `asm cgo compile cover link preprofile vet` ❌ |
| real go1.25.x install | same short list, **but** builds `covdata` on demand ✅ |

`make test` runs gotestsum with `-cover -coverprofile` over `go list ./...`, which includes the repo root (`main.go`, no test files). Go 1.25 needs `covdata` to synthesize 0% coverage for a package with no tests, so the run ends in `go: no such tool "covdata"` and make exits 1 — **even though all 33 tests pass**. That is exactly what the four Dependabot PRs show.

## Verification

Same working tree, only the toolchain source differs:

```
# system Go 1.24.2 + GOTOOLCHAIN=auto  (what CI does today)
go: no such tool "covdata"
DONE 33 tests, 1 error in 2.388s
make: *** [test] Error 1

# real Go 1.25 install  (what this PR makes CI do)
DONE 33 tests in 12.751s
test EXIT=0
```

Reading the version from `go.mod` installs a real Go distribution matching the module, so `covdata` is available. It also removes the existing 1.21-vs-1.24 drift.

## Note

`run-integration-tests` is expected to be green here — this is an in-repo branch, so it receives repository secrets. Dependabot and fork PRs do not, which is the separate reason their integration check reads `auth keys missing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)