### PR TITLE
ci: group Dependabot updates for golang.org/x and terraform-plugin-*

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      # These modules share a release train and move together, so ungrouped
+      # updates arrive as several PRs that all touch the same module graph and
+      # invalidate each other on merge.
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
+      hashicorp-terraform:
+        patterns:
+          - "github.com/hashicorp/terraform-*"


### PR DESCRIPTION
Independent of the other PRs in this stack — can merge in any order.

Three separate open PRs (#731 `x/crypto`, #735 `x/text`, #737 `grpc`) each bumped an overlapping slice of the same `golang.org/x` module graph. Merging any one of them would force the other two to rebase, and none of them individually reached a version that cleared every open advisory — see #739 for the details.

Grouping the families that share a release train means one PR per family per week instead of several mutually-invalidating ones.

```yaml
    groups:
      golang-x:
        patterns:
          - "golang.org/x/*"
      hashicorp-terraform:
        patterns:
          - "github.com/hashicorp/terraform-*"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)