### PR TITLE
fix(test): match new StringInSlice error format from plugin-sdk v2.40.1

### DIFF
--- a/integration/resource_lacework_alert_rule_test.go
+++ b/integration/resource_lacework_alert_rule_test.go
@@ -183,7 +183,7 @@ func TestAlertRuleCategories(t *testing.T) {
 	if assert.Error(t, err) {
 		assert.Contains(t,
 			err.Error(),
-			"expected alert_subcategories.0 to be one of [Compliance Application Cloud Activity File Machine User Platform Kubernetes Activity Registry SystemCall Host Vulnerability Container Vulnerability Threat Intel App Cloud K8sActivity]",
+			`expected alert_subcategories.0 to be one of ["Compliance" "Application" "Cloud Activity" "File" "Machine" "User" "Platform" "Kubernetes Activity" "Registry" "SystemCall" "Host Vulnerability" "Container Vulnerability" "Threat Intel" "App" "Cloud" "K8sActivity"]`,
 		)
 	}
 }
@@ -231,7 +231,7 @@ func TestAlertRuleDeprecatedEventCategories(t *testing.T) {
 	if assert.Error(t, err) {
 		assert.Contains(t,
 			err.Error(),
-			"expected event_categories.0 to be one of [Compliance Application Cloud Activity File Machine User Platform Kubernetes Activity Registry SystemCall Host Vulnerability Container Vulnerability Threat Intel App Cloud K8sActivity]",
+			`expected event_categories.0 to be one of ["Compliance" "Application" "Cloud Activity" "File" "Machine" "User" "Platform" "Kubernetes Activity" "Registry" "SystemCall" "Host Vulnerability" "Container Vulnerability" "Threat Intel" "App" "Cloud" "K8sActivity"]`,
 		)
 	}
 }


### PR DESCRIPTION
Fixes the two integration tests that have been failing on `main` since #740. The post-merge run on `main` for that PR is currently red.

## What broke

**The provider is fine** — it still rejects the invalid value correctly. Only the wording of the SDK's validation error changed.

`helper/validation.StringInSlice` formats the set of valid values with `%q` as of v2.40.1, where v2.27.0 used `%v`:

```
before  expected alert_subcategories.0 to be one of [Compliance Application Cloud Activity ...]
after   expected alert_subcategories.0 to be one of ["Compliance" "Application" "Cloud Activity" ...]
```

`TestAlertRuleCategories` and `TestAlertRuleDeprecatedEventCategories` assert on that string via `assert.Contains`, so they stopped matching. 66 of 68 integration tests still passed.

## Scope

`IntInSlice` still formats with `%v`:

```go
// int.go   errors = append(errors, fmt.Errorf("expected %s to be one of %v, got %d", k, valid, v))
// strings.go errors = append(errors, fmt.Errorf("expected %s to be one of %q, got %s", k, valid, v))
```

so the similar assertion in `integration/resource_lacework_integration_ecr_test.go:86` is unaffected and left alone.

## Verification

The two expected strings were **generated** from `api.AlertRuleSubCategories` using the same format string the SDK uses and compared byte-for-byte against the literals in the test — not transcribed by hand from the CI log. `make fmtcheck` and `go vet ./integration/...` are clean.

Worth noting these assertions are inherently brittle: they pin an SDK-owned message format *and* the full category list. If you would rather they assert only the stable part (`"expected alert_subcategories.0 to be one of"` plus `"got INVALID"`), say so and I will switch them — that survives both format changes and category-list changes, at the cost of no longer pinning the valid set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)