### PR TITLE
ci: bump actions/setup-go to v6 so the toolchain directive is honoured

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -35,7 +35,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -62,7 +62,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -16,7 +16,7 @@ jobs:
           ref: main
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -39,7 +39,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -66,7 +66,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Install Terraform


### PR DESCRIPTION
Closes the residual gap left by #738.

## The gap

#738 made CI read the Go version from `go.mod`, which fixed the `covdata` failures. But `setup-go@v4` parses only the **`go`** directive and ignores **`toolchain`**.

That is harmless today — `go.mod` carries no `toolchain` line. It is a loaded gun for later. If one above the `go` directive is ever reintroduced (Dependabot adds one, or a `go get` on a machine with a newer local Go writes one), setup-go installs the older `go` version, and the go command satisfies the `toolchain` line by downloading a **module-cache toolchain**. Go 1.25+ module toolchains ship no prebuilt `covdata` and cannot build one, because the module cache is read-only — so `make test` fails with `go: no such tool "covdata"` *after every test passes*.

That is precisely the failure #738 diagnosed, and it was not a quick one to track down.

## The fix

`setup-go@v6` reads the toolchain directive first and falls back to the `go` directive, so the installed toolchain always matches what the module actually demands:

```js
if (process.env[GOTOOLCHAIN_ENV_VAR] !== GOTOOLCHAIN_LOCAL_VAL) {
  const matchToolchain = contents.match(/^toolchain go(1\.\d+(?:\.\d+|rc\d+)?)/m)
  if (matchToolchain) return matchToolchain[1]
}
const matchGo = contents.match(/^go (\d+(\.\d+)*)/m)
```

Verified this parsing is present in the `v6` tag — it is **not** in `v5`, which still parses only the `go` directive.

## Why v6 and not v7

v7.0.0 is three weeks old (2026-07-16) and is an ESM migration; it carries no additional benefit here. v6 already has the toolchain parsing and already runs on **node24**, which also clears the Node 20 deprecation warnings setup-go emits on every run today.

`actions/checkout@v4` still emits the same Node 20 warning. Left alone as unrelated to this fix — worth its own PR.

## Expected behaviour

No change in resolved version today: `go.mod` says `go 1.25.8` with no toolchain line, so v6 installs 1.25.8 exactly as v4 does now. This is purely future-proofing, so a green run here is the whole verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)